### PR TITLE
NH-18292-Change-API-Object-Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ sure it is available in the environment where your application is running:
 export SW_APM_SERVICE_KEY="api-token-here:your-service-name"
 ```
 
-Then, at the top of your main js file for your app, add this:
+Then require `solarwinds-apm` as part of your application start command, or via require() call in your entry point file before any other require() calls. Below are simple examples:
+
+```
+node -r solarwinds-apm <app.js>
+```
 
 ```
 require('solarwinds-apm')
@@ -57,10 +61,10 @@ command to invoke your program `node -r esm index.js` then `esm.js` is loaded fi
 `solarwinds-apm` is unable to instrument modules. You can use it, just make sure to require
 `solarwinds-apm` first, e.g., `node -r solarwinds-apm -r esm index.js`.
 
-If you are using the custom instrumentation SDK then SolarWinds APM must be loaded in the code
-so that a reference to the SDK is obtained, like `const ao = require('solarwinds-apm')`. It
-is still be possible to use the command line `node -r solarwinds-apm -r esm index.js`; the
-require in the code will just get a reference to the results of the command line require.
+If you are using the custom instrumentation SDK then a reference to the SDK must be obtained, 
+like `const apm = require('solarwinds-apm')`. It you  use the command line option to require
+`solarwinds-apm` (e.g. `node -r solarwinds-apm -r esm index.js`) you can access the SDK using
+`const apm = global[Symbol.for('SolarWinds.Apm.Once')]`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ command to invoke your program `node -r esm index.js` then `esm.js` is loaded fi
 If you are using the custom instrumentation SDK then a reference to the SDK must be obtained, 
 like `const apm = require('solarwinds-apm')`. It you  use the command line option to require
 `solarwinds-apm` (e.g. `node -r solarwinds-apm -r esm index.js`) you can access the SDK using
-`const apm = global[Symbol.for('SolarWinds.Apm.Once')]`
+`const apm = global[Symbol.for('solarwinds-apm')]`
 
 ## Configuration
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 ## Classes
 
 <dl>
-<dt><a href="#ao">ao</a></dt>
+<dt><a href="#apm">apm</a></dt>
 <dd></dd>
 <dt><a href="#Span">Span</a></dt>
 <dd></dd>
@@ -24,42 +24,42 @@
 <dd></dd>
 </dl>
 
-<a name="ao"></a>
+<a name="apm"></a>
 
-## ao
+## apm
 **Kind**: global class  
 
-* [ao](#ao)
-    * [.logLevel](#ao.logLevel)
-    * [.loggers](#ao.loggers)
-    * [.traceMode](#ao.traceMode)
-    * [.tracing](#ao.tracing)
-    * [.traceId](#ao.traceId)
-    * [.logLevelAdd(levels)](#ao.logLevelAdd) ⇒ <code>string</code> \| <code>undefined</code>
-    * [.logLevelRemove(levels)](#ao.logLevelRemove) ⇒ <code>string</code> \| <code>undefined</code>
-    * [.backtrace()](#ao.backtrace) ⇒ <code>string</code>
-    * [.bind(fn)](#ao.bind) ⇒ <code>function</code>
-    * [.bindEmitter(em)](#ao.bindEmitter) ⇒ <code>EventEmitter</code>
-    * [.setCustomTxNameFunction(probe, fn)](#ao.setCustomTxNameFunction) ⇒ <code>boolean</code>
-    * [.readyToSample(ms, [obj])](#ao.readyToSample) ⇒ <code>boolean</code>
-    * [.sampling(item)](#ao.sampling) ⇒ <code>boolean</code>
-    * [.traceToEvent(traceparent)](#ao.traceToEvent) ⇒ <code>addon.Event</code> \| <code>undefined</code>
-    * [.instrumentHttp(span, run, [options], res)](#ao.instrumentHttp) ⇒
-    * [.instrument(span, run, [options], [callback])](#ao.instrument) ⇒ <code>value</code>
-    * [.pInstrument(span, run, [options])](#ao.pInstrument) ⇒ <code>Promise</code>
-    * [.startOrContinueTrace(traceparent, tracestate, span, runner, [opts], [callback])](#ao.startOrContinueTrace) ⇒ <code>value</code>
-    * [.pStartOrContinueTrace(traceparent, tracestate, span, run, [opts])](#ao.pStartOrContinueTrace) ⇒ <code>Promise</code>
-    * [.reportError(error)](#ao.reportError)
-    * [.reportInfo(data)](#ao.reportInfo)
-    * [.sendMetrics(metrics, [gopts])](#ao.sendMetrics) ⇒ [<code>SendMetricsReturn</code>](#SendMetricsReturn)
-    * [.getTraceObjectForLog()](#ao.getTraceObjectForLog) ⇒ <code>object</code>
-    * [.getTraceStringForLog([delimiter])](#ao.getTraceStringForLog) ⇒ <code>string</code>
-    * [.wrapLambdaHandler([handler])](#ao.wrapLambdaHandler) ⇒ <code>function</code>
+* [apm](#apm)
+    * [.logLevel](#apm.logLevel)
+    * [.loggers](#apm.loggers)
+    * [.traceMode](#apm.traceMode)
+    * [.tracing](#apm.tracing)
+    * [.traceId](#apm.traceId)
+    * [.logLevelAdd(levels)](#apm.logLevelAdd) ⇒ <code>string</code> \| <code>undefined</code>
+    * [.logLevelRemove(levels)](#apm.logLevelRemove) ⇒ <code>string</code> \| <code>undefined</code>
+    * [.backtrace()](#apm.backtrace) ⇒ <code>string</code>
+    * [.bind(fn)](#apm.bind) ⇒ <code>function</code>
+    * [.bindEmitter(em)](#apm.bindEmitter) ⇒ <code>EventEmitter</code>
+    * [.setCustomTxNameFunction(probe, fn)](#apm.setCustomTxNameFunction) ⇒ <code>boolean</code>
+    * [.readyToSample(ms, [obj])](#apm.readyToSample) ⇒ <code>boolean</code>
+    * [.sampling(item)](#apm.sampling) ⇒ <code>boolean</code>
+    * [.traceToEvent(traceparent)](#apm.traceToEvent) ⇒ <code>addon.Event</code> \| <code>undefined</code>
+    * [.instrumentHttp(span, run, [options], res)](#apm.instrumentHttp) ⇒
+    * [.instrument(span, run, [options], [callback])](#apm.instrument) ⇒ <code>value</code>
+    * [.pInstrument(span, run, [options])](#apm.pInstrument) ⇒ <code>Promise</code>
+    * [.startOrContinueTrace(traceparent, tracestate, span, runner, [opts], [callback])](#apm.startOrContinueTrace) ⇒ <code>value</code>
+    * [.pStartOrContinueTrace(traceparent, tracestate, span, run, [opts])](#apm.pStartOrContinueTrace) ⇒ <code>Promise</code>
+    * [.reportError(error)](#apm.reportError)
+    * [.reportInfo(data)](#apm.reportInfo)
+    * [.sendMetrics(metrics, [gopts])](#apm.sendMetrics) ⇒ [<code>SendMetricsReturn</code>](#SendMetricsReturn)
+    * [.getTraceObjectForLog()](#apm.getTraceObjectForLog) ⇒ <code>object</code>
+    * [.getTraceStringForLog([delimiter])](#apm.getTraceStringForLog) ⇒ <code>string</code>
+    * [.wrapLambdaHandler([handler])](#apm.wrapLambdaHandler) ⇒ <code>function</code>
 
-<a name="ao.logLevel"></a>
+<a name="apm.logLevel"></a>
 
-### ao.logLevel
-**Kind**: static property of [<code>ao</code>](#ao)  
+### apm.logLevel
+**Kind**: static property of [<code>apm</code>](#apm)  
 **Properties**
 
 | Type | Description |
@@ -68,43 +68,43 @@
 
 **Example** *(Sets the log settings)*  
 ```js
-ao.logLevel = 'warn,error'
+apm.logLevel = 'warn,error'
 ```
 **Example** *(Get the log settings)*  
 ```js
-var settings = ao.logLevel
+var settings = apm.logLevel
 ```
-<a name="ao.loggers"></a>
+<a name="apm.loggers"></a>
 
-### ao.loggers
+### apm.loggers
 Expose debug logging global and create a function to turn
 logging on/off.
 
-**Kind**: static property of [<code>ao</code>](#ao)  
+**Kind**: static property of [<code>apm</code>](#apm)  
 **Properties**
 
 | Type | Description |
 | --- | --- |
 | <code>object</code> | the loggers available for use |
 
-<a name="ao.traceMode"></a>
+<a name="apm.traceMode"></a>
 
-### ao.traceMode
+### apm.traceMode
 Get and set the trace mode
 
-**Kind**: static property of [<code>ao</code>](#ao)  
+**Kind**: static property of [<code>apm</code>](#apm)  
 **Properties**
 
 | Type | Description |
 | --- | --- |
 | <code>string</code> | the sample mode |
 
-<a name="ao.tracing"></a>
+<a name="apm.tracing"></a>
 
-### ao.tracing
+### apm.tracing
 Return whether or not the current code path is being traced.
 
-**Kind**: static property of [<code>ao</code>](#ao)  
+**Kind**: static property of [<code>apm</code>](#apm)  
 **Read only**: true  
 **Properties**
 
@@ -112,12 +112,12 @@ Return whether or not the current code path is being traced.
 | --- |
 | <code>boolean</code> | 
 
-<a name="ao.traceId"></a>
+<a name="apm.traceId"></a>
 
-### ao.traceId
+### apm.traceId
 Get X-Trace ID of the last event
 
-**Kind**: static property of [<code>ao</code>](#ao)  
+**Kind**: static property of [<code>apm</code>](#apm)  
 **Read only**: true  
 **Properties**
 
@@ -125,12 +125,12 @@ Get X-Trace ID of the last event
 | --- | --- |
 | <code>string</code> | the trace ID as a string or undefined if not tracing. |
 
-<a name="ao.logLevelAdd"></a>
+<a name="apm.logLevelAdd"></a>
 
-### ao.logLevelAdd(levels) ⇒ <code>string</code> \| <code>undefined</code>
+### apm.logLevelAdd(levels) ⇒ <code>string</code> \| <code>undefined</code>
 Add log levels to the existing set of log levels.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>string</code> \| <code>undefined</code> - - the current log levels or undefined if an error  
 
 | Param | Type | Description |
@@ -139,14 +139,14 @@ Add log levels to the existing set of log levels.
 
 **Example**  
 ```js
-ao.logLevelAdd('warn,debug')
+apm.logLevelAdd('warn,debug')
 ```
-<a name="ao.logLevelRemove"></a>
+<a name="apm.logLevelRemove"></a>
 
-### ao.logLevelRemove(levels) ⇒ <code>string</code> \| <code>undefined</code>
+### apm.logLevelRemove(levels) ⇒ <code>string</code> \| <code>undefined</code>
 Remove log levels from the current set.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>string</code> \| <code>undefined</code> - - log levels after removals or undefined if an
                              error.  
 
@@ -156,23 +156,23 @@ Remove log levels from the current set.
 
 **Example**  
 ```js
-var previousLogLevel = ao.logLevel
-ao.logLevelAdd('debug')
-ao.logLevelRemove(previousLogLevel)
+var previousLogLevel = apm.logLevel
+apm.logLevelAdd('debug')
+apm.logLevelRemove(previousLogLevel)
 ```
-<a name="ao.backtrace"></a>
+<a name="apm.backtrace"></a>
 
-### ao.backtrace() ⇒ <code>string</code>
+### apm.backtrace() ⇒ <code>string</code>
 Generate a backtrace string
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>string</code> - the backtrace  
-<a name="ao.bind"></a>
+<a name="apm.bind"></a>
 
-### ao.bind(fn) ⇒ <code>function</code>
+### apm.bind(fn) ⇒ <code>function</code>
 Bind a function to the CLS context if tracing.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>function</code> - The bound function or the unmodified argument if it can't
   be bound.  
 
@@ -180,25 +180,25 @@ Bind a function to the CLS context if tracing.
 | --- | --- | --- |
 | fn | <code>function</code> | The function to bind to the context |
 
-<a name="ao.bindEmitter"></a>
+<a name="apm.bindEmitter"></a>
 
-### ao.bindEmitter(em) ⇒ <code>EventEmitter</code>
+### apm.bindEmitter(em) ⇒ <code>EventEmitter</code>
 Bind an emitter if tracing
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>EventEmitter</code> - The bound emitter or the original emitter if an error.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | em | <code>EventEmitter</code> | The emitter to bind to the trace context |
 
-<a name="ao.setCustomTxNameFunction"></a>
+<a name="apm.setCustomTxNameFunction"></a>
 
-### ao.setCustomTxNameFunction(probe, fn) ⇒ <code>boolean</code>
+### apm.setCustomTxNameFunction(probe, fn) ⇒ <code>boolean</code>
 Set a custom transaction name function for a specific probe. This is
 most commonly used when setting custom names for all or most routes.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>boolean</code> - true if successfully set else false  
 
 | Param | Type | Description |
@@ -212,13 +212,13 @@ most commonly used when setting custom names for all or most routes.
 express: customFunction (req, res)
 hapi/hapi: customFunction (request)
 ```
-<a name="ao.readyToSample"></a>
+<a name="apm.readyToSample"></a>
 
-### ao.readyToSample(ms, [obj]) ⇒ <code>boolean</code>
+### apm.readyToSample(ms, [obj]) ⇒ <code>boolean</code>
 Check whether the agent is ready to sample. It will wait up to
 the specified number of milliseconds before returning.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>boolean</code> - - true if ready to sample; false if not  
 
 | Param | Type | Description |
@@ -226,25 +226,25 @@ the specified number of milliseconds before returning.
 | ms | <code>Number</code> | milliseconds to wait; default 0 means don't wait (poll). |
 | [obj] | <code>Object</code> | if present obj.status will receive low level status |
 
-<a name="ao.sampling"></a>
+<a name="apm.sampling"></a>
 
-### ao.sampling(item) ⇒ <code>boolean</code>
+### apm.sampling(item) ⇒ <code>boolean</code>
 Determine if the sample flag is set for the various forms of
  data.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>boolean</code> - - true if the sample flag is set else false.  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | item | <code>string</code> \| [<code>Event</code>](#Event) \| <code>addon.Event</code> | the item to get the sampling flag of |
 
-<a name="ao.traceToEvent"></a>
+<a name="apm.traceToEvent"></a>
 
-### ao.traceToEvent(traceparent) ⇒ <code>addon.Event</code> \| <code>undefined</code>
+### apm.traceToEvent(traceparent) ⇒ <code>addon.Event</code> \| <code>undefined</code>
 Convert an traceparent ID to an event containing the task ID and op ID.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>addon.Event</code> \| <code>undefined</code> - - addon.Event object
                                      containing an internal
                                      format of the traceparent
@@ -255,12 +255,12 @@ Convert an traceparent ID to an event containing the task ID and op ID.
 | --- | --- | --- |
 | traceparent | <code>string</code> | traceparent ID |
 
-<a name="ao.instrumentHttp"></a>
+<a name="apm.instrumentHttp"></a>
 
-### ao.instrumentHttp(span, run, [options], res) ⇒
+### apm.instrumentHttp(span, run, [options], res) ⇒
 Instrument HTTP request/response
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: the value returned by the run function or undefined if it can't be run.  
 
 | Param | Type | Description |
@@ -272,12 +272,12 @@ Instrument HTTP request/response
 | [options.collectBacktraces] | <code>object</code> | collect backtraces |
 | res | <code>HTTPResponse</code> | HTTP response to patch |
 
-<a name="ao.instrument"></a>
+<a name="apm.instrument"></a>
 
-### ao.instrument(span, run, [options], [callback]) ⇒ <code>value</code>
+### apm.instrument(span, run, [options], [callback]) ⇒ <code>value</code>
 Apply custom instrumentation to a synchronous or async-callback function.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>value</code> - the value returned by the run function or undefined if it can't be run  
 
 | Param | Type | Default | Description |
@@ -307,7 +307,7 @@ function run () {
   // do things with contents
 }
 
-ao.instrument(spanInfo, run)
+apm.instrument(spanInfo, run)
 ```
 **Example**  
 ```js
@@ -334,14 +334,14 @@ function callback (err, data) {
   console.log('file contents are: ' + data)
 }
 
-ao.instrument(spanInfo, run, callback)
+apm.instrument(spanInfo, run, callback)
 ```
-<a name="ao.pInstrument"></a>
+<a name="apm.pInstrument"></a>
 
-### ao.pInstrument(span, run, [options]) ⇒ <code>Promise</code>
+### apm.pInstrument(span, run, [options]) ⇒ <code>Promise</code>
 Apply custom instrumentation to a promise-returning asynchronous function.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>Promise</code> - the value returned by the run function or undefined if it can't be run  
 
 | Param | Type | Default | Description |
@@ -372,16 +372,16 @@ function run () {
   })
 }
 
-ao.pInstrument(spanInfo, run).then(...)
+apm.pInstrument(spanInfo, run).then(...)
 ```
-<a name="ao.startOrContinueTrace"></a>
+<a name="apm.startOrContinueTrace"></a>
 
-### ao.startOrContinueTrace(traceparent, tracestate, span, runner, [opts], [callback]) ⇒ <code>value</code>
+### apm.startOrContinueTrace(traceparent, tracestate, span, runner, [opts], [callback]) ⇒ <code>value</code>
 Start or continue a trace. Continue is in the sense of continuing a
 trace based on an X-Trace ID received from an external source, e.g.,
 HTTP headers or message queue headers.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>value</code> - the value returned by the run function or undefined if it can't be run  
 
 | Param | Type | Default | Description |
@@ -399,7 +399,7 @@ HTTP headers or message queue headers.
 
 **Example**  
 ```js
-ao.startOrContinueTrace(
+apm.startOrContinueTrace(
   null,
   'sync-span-name',
   functionToRun,           // synchronous so function takes no arguments
@@ -408,7 +408,7 @@ ao.startOrContinueTrace(
 ```
 **Example**  
 ```js
-ao.startOrContinueTrace(
+apm.startOrContinueTrace(
   null,
   'sync-span-name',
   functionToRun,
@@ -428,7 +428,7 @@ function asyncFunctionToRun (cb) {
 }
 // and realCallback is supplied as the optional callback parameter
 
-ao.startOrContinueTrace(
+apm.startOrContinueTrace(
   null,
   'async-span-name',
   asyncFunctionToRun,     // async, so function takes one argument
@@ -436,14 +436,14 @@ ao.startOrContinueTrace(
   realCallback            // receives request's callback arguments.
 )
 ```
-<a name="ao.pStartOrContinueTrace"></a>
+<a name="apm.pStartOrContinueTrace"></a>
 
-### ao.pStartOrContinueTrace(traceparent, tracestate, span, run, [opts]) ⇒ <code>Promise</code>
+### apm.pStartOrContinueTrace(traceparent, tracestate, span, run, [opts]) ⇒ <code>Promise</code>
 Start or continue a trace running a function that returns a promise. Continue is in
 the sense of continuing a trace based on an X-Trace ID received from an external
 source, e.g., HTTP headers or message queue headers.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>Promise</code> - the value returned by the run function or undefined if it can't be run  
 
 | Param | Type | Default | Description |
@@ -472,37 +472,37 @@ function functionToRun () {
   })
 }
 
-ao.pStartOrContinueTrace(
+apm.pStartOrContinueTrace(
   null,
   spanInfo,
   functionToRun,
 ).then(...)
 ```
-<a name="ao.reportError"></a>
+<a name="apm.reportError"></a>
 
-### ao.reportError(error)
+### apm.reportError(error)
 Report an error event in the current trace.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | error | <code>Error</code> | The error instance to report |
 
-<a name="ao.reportInfo"></a>
+<a name="apm.reportInfo"></a>
 
-### ao.reportInfo(data)
+### apm.reportInfo(data)
 Report an info event in the current trace.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 
 | Param | Type | Description |
 | --- | --- | --- |
 | data | <code>object</code> | Data to report in the info event |
 
-<a name="ao.sendMetrics"></a>
+<a name="apm.sendMetrics"></a>
 
-### ao.sendMetrics(metrics, [gopts]) ⇒ [<code>SendMetricsReturn</code>](#SendMetricsReturn)
+### apm.sendMetrics(metrics, [gopts]) ⇒ [<code>SendMetricsReturn</code>](#SendMetricsReturn)
 Send custom metrics. There are two types of metrics:
 1) count-based - the number of times something has occurred (no
                  value is associated with this type)
@@ -511,7 +511,7 @@ Send custom metrics. There are two types of metrics:
 The metrics submitted are aggregated by metric name and tag(s), then
 sent every 60 seconds.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -523,11 +523,11 @@ sent every 60 seconds.
 **Example**  
 ```js
 // send a single metric
-ao.sendMetrics({name: 'my.counts.basic'});
-ao.sendMetrics({name: 'my.values.some', value: 42.42});
+apm.sendMetrics({name: 'my.counts.basic'});
+apm.sendMetrics({name: 'my.values.some', value: 42.42});
 
 // send multiple metrics (most efficient)
-ao.sendMetrics([
+apm.sendMetrics([
   // default count is 1
   {name: 'my.counts.defaulted'},
   {name: 'my.counts.multiple', count: 3},
@@ -537,17 +537,17 @@ ao.sendMetrics([
 ]);
 
 // add tags that can be used for filtering on the host
-ao.sendMetrics([
+apm.sendMetrics([
   {name: 'my.metric.end-of-file', tags: {class: 'error', subsystem: 'fs'}}
 ]);
 
 // add a hostname tag automatically.
-ao.sendMetrics([
+apm.sendMetrics([
   {name: 'my.metric.end-of-file', tags: {class: 'error'}, addHostTag: true}
 ]);
 
 // add a hostname tag and an application tag to each metric.
-ao.sendMetrics(
+apm.sendMetrics(
   [
     {name: 'my.metric', tags: {class: 'status'}},
     {name: 'my.time', value: 33.3, tags: {class: 'performance'}}
@@ -557,7 +557,7 @@ ao.sendMetrics(
 
 // default class to 'status' for metrics that don't supply a class
 // tag.
-ao.sendMetrics(
+apm.sendMetrics(
   [
     {name: 'my.metric'},
     {name: 'my.time', value: 33.3, tags: {class: 'performance'}}
@@ -565,19 +565,19 @@ ao.sendMetrics(
   {tags: {class: 'status'}}
 );
 ```
-<a name="ao.getTraceObjectForLog"></a>
+<a name="apm.getTraceObjectForLog"></a>
 
-### ao.getTraceObjectForLog() ⇒ <code>object</code>
+### apm.getTraceObjectForLog() ⇒ <code>object</code>
 Return an object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
 to insert custom tokens in log packages.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>object</code> - - the trace log  object (e.g. { trace_id:..., span_id: ..., trace_flages: ...})  
 **Example**  
 ```js
 log4js.addLayout('json', function (config) {
   return function (logEvent) {
-    logEvent.context = { ...logEvent.context, ...ao.getTraceObjectForLog() }
+    logEvent.context = { ...logEvent.context, ...apm.getTraceObjectForLog() }
     return JSON.stringify(logEvent)
   }
 })
@@ -592,13 +592,13 @@ log4js.configure({
 const logger = log4js.getLogger()
 logger.info('doing something.')
 ```
-<a name="ao.getTraceStringForLog"></a>
+<a name="apm.getTraceStringForLog"></a>
 
-### ao.getTraceStringForLog([delimiter]) ⇒ <code>string</code>
+### apm.getTraceStringForLog([delimiter]) ⇒ <code>string</code>
 Return text delimited representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
 to insert custom tokens in log packages.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>string</code> - - the trace log string (e.g. trace_id:... span_id: ..., trace_flages: ...)  
 
 | Param | Type | Description |
@@ -619,7 +619,7 @@ log4js.configure({
             return 'Jake'
           },
           trace: function () {
-            return typeof ao !=='undefined' ? ao.getTraceStringForLog() : ''
+            return typeof apm !=='undefined' ? apm.getTraceStringForLog() : ''
           }
         }
       }
@@ -630,12 +630,12 @@ log4js.configure({
 const logger = log4js.getLogger()
 logger.info('token from api')
 ```
-<a name="ao.wrapLambdaHandler"></a>
+<a name="apm.wrapLambdaHandler"></a>
 
-### ao.wrapLambdaHandler([handler]) ⇒ <code>function</code>
+### apm.wrapLambdaHandler([handler]) ⇒ <code>function</code>
 Wrap the lambda handler function so it can be traced by AppOptics APM.
 
-**Kind**: static method of [<code>ao</code>](#ao)  
+**Kind**: static method of [<code>apm</code>](#apm)  
 **Returns**: <code>function</code> - - an async function, wrapping handler, to be used
                       instead of handler.  
 
@@ -645,9 +645,9 @@ Wrap the lambda handler function so it can be traced by AppOptics APM.
 
 **Example**  
 ```js
-const ao = require('appoptics-apm');
+const apm = require('appoptics-apm');
 
-const wrappedHandler = ao.wrapLambdaHandler(myHandler);
+const wrappedHandler = apm.wrapLambdaHandler(myHandler);
 
 async function myHandler (event, context) {
   // implementation
@@ -659,9 +659,9 @@ exports.handler = wrappedHandler;
 ```
 **Example**  
 ```js
-const ao = require('appoptics-apm');
+const apm = require('appoptics-apm');
 
-const wrappedHandler = ao.wrapLambdaHandler(myHandler);
+const wrappedHandler = apm.wrapLambdaHandler(myHandler);
 
 function myHandler (event, context, callback) {
   // implementation
@@ -711,7 +711,7 @@ Create an execution span.
 
 **Example**  
 ```js
-var span = new Span('fs', ao.lastEvent, {
+var span = new Span('fs', apm.lastEvent, {
   File: file
 })
 ```
@@ -840,7 +840,7 @@ span.exit()
 // manually and bind the callback to maintain the trace context
 span.async = true
 span.enter()
-asyncCallToTrace(ao.bind(function (err, res) {
+asyncCallToTrace(apm.bind(function (err, res) {
   span.exit()
   callback(err, res)
 }))
@@ -921,7 +921,7 @@ header was attached to an inbound HTTP/HTTPS request.
 | Param | Type | Description |
 | --- | --- | --- |
 | name | <code>string</code> | the name for the span. |
-| settings | <code>object</code> | the object returned by ao.getTraceSettings() |
+| settings | <code>object</code> | the object returned by apm.getTraceSettings() |
 | kvpairs | <code>object</code> | key/value pairs to be added to the entry event |
 
 <a name="Event"></a>
@@ -946,7 +946,7 @@ Create an event
 | --- | --- | --- |
 | span | <code>string</code> | name of the event's span |
 | label | <code>string</code> | Event label (usually entry or exit) |
-| parent | <code>aob.Event</code> | supplies the taskId to construct the event from. |
+| parent | <code>apmb.Event</code> | supplies the taskId to construct the event from. |
 | edge | <code>boolean</code> | This should edge back to the parent |
 
 <a name="Event+set"></a>

--- a/lib/api-sim.js
+++ b/lib/api-sim.js
@@ -1,20 +1,20 @@
 'use strict'
 
-let ao
-let aob
+let apm
+let apmb
 let cls
 
 module.exports = function (agent) {
-  ao = agent
-  aob = ao.addon
+  apm = agent
+  apmb = apm.addon
   // check for property to avoid triggering node 14 warning on
   // non-existent property in unfinished module.exports
-  if (Object.prototype.hasOwnProperty.call(ao, 'cls')) {
-    cls = ao.cls
+  if (Object.prototype.hasOwnProperty.call(apm, 'cls')) {
+    cls = apm.cls
   }
 
   // define the properties (some of which are part of the API)
-  definePropertiesOn(ao)
+  definePropertiesOn(apm)
 
   // make these globally available
   class Event {}
@@ -27,7 +27,7 @@ module.exports = function (agent) {
   Span.init = function () {}
   Span.makeEntrySpan = function makeEntrySpan (name, settings, data) {
     // use the task id from settings or (primarily used in testing) make new.
-    const traceTaskId = settings.traceTaskId || ao.addon.Event.makeRandom(settings.doSample)
+    const traceTaskId = settings.traceTaskId || apm.addon.Event.makeRandom(settings.doSample)
 
     const span = new Span(name, { traceTaskId, edge: settings.edge }, data)
 
@@ -82,80 +82,80 @@ module.exports = function (agent) {
   }
 }
 
-function definePropertiesOn (ao) {
-  Object.defineProperty(ao, 'traceMode', {
-    get () { return ao.modeToStringMap[0] },
+function definePropertiesOn (apm) {
+  Object.defineProperty(apm, 'traceMode', {
+    get () { return apm.modeToStringMap[0] },
     set (value) {
       // ignore any attempts to set traceMode.
     }
   })
 
-  Object.defineProperty(ao, 'sampleRate', {
+  Object.defineProperty(apm, 'sampleRate', {
     get () { return 0 },
     set (value) {
       // ignore any attempt to set the sampleRate.
     }
   })
 
-  Object.defineProperty(ao, 'tracing', {
+  Object.defineProperty(apm, 'tracing', {
     get () { return false }
   })
 
-  Object.defineProperty(ao, 'traceId', {
+  Object.defineProperty(apm, 'traceId', {
     get () { return undefined }
   })
 
-  Object.defineProperty(ao, 'lastEvent', {
+  Object.defineProperty(apm, 'lastEvent', {
     get () { return undefined }
   })
 
-  Object.defineProperty(ao, 'lastSpan', {
+  Object.defineProperty(apm, 'lastSpan', {
     get () { return undefined }
   })
 
   const maps = {}
-  Object.defineProperty(ao, 'maps', {
+  Object.defineProperty(apm, 'maps', {
     get () { return maps }
   })
 
-  const storeName = 'ao-cls-context'
+  const storeName = 'apm-cls-context'
 
-  Object.defineProperty(ao, 'requestStore', {
+  Object.defineProperty(apm, 'requestStore', {
     get () { return cls.getNamespace(storeName) || cls.createNamespace(storeName) }
   })
 
-  ao.resetRequestStore = function () {
+  apm.resetRequestStore = function () {
     cls.destroyNamespace(storeName)
   }
 
-  ao.clsCheck = function (msg) {
+  apm.clsCheck = function (msg) {
     return false
   }
 
-  ao.stack = function (test, n) {
+  apm.stack = function (test, n) {
     return ''
   }
 
-  ao.bind = function (fn) {
+  apm.bind = function (fn) {
     return fn
   }
 
-  ao.bindEmitter = function (em) {
+  apm.bindEmitter = function (em) {
     return em
   }
 
-  ao.backtrace = function () {
+  apm.backtrace = function () {
     const e = new Error('backtrace')
     return e.stack.replace(/[^\n]*\n\s+/, '').replace(/\n\s*/g, '\n')
   }
 
-  ao.setCustomTxNameFunction = function (probe, fn) {
+  apm.setCustomTxNameFunction = function (probe, fn) {
     return false
   }
 }
 
 function readyToSample (ms, obj) {
-  const status = aob.isReadyToSample(ms)
+  const status = apmb.isReadyToSample(ms)
   // if the caller wants the actual status provide it
   if (obj && typeof obj === 'object') {
     obj.status = status
@@ -169,7 +169,7 @@ function getTraceSettings (traceparent, tracestate, options) {
   // liboobe still uses the term xtrace in keys (and thus so do the bindings) even though
   // the format is now that of traceparnet (dash delimited).
   // put traceparent value into xtrace key
-  const osettings = aob.Settings.getTraceSettings({ xtrace: traceparent, tracestate })
+  const osettings = apmb.Settings.getTraceSettings({ xtrace: traceparent, tracestate })
   // compatibility to avoid a synchronized bindings release
   if (!osettings.traceTaskId) {
     osettings.traceTaskId = osettings.metadata
@@ -182,7 +182,7 @@ function sampling (item) {
 }
 
 function traceToEvent (traceparent) {
-  return aob.Event.makeFromString(traceparent)
+  return apmb.Event.makeFromString(traceparent)
 }
 
 function patchResponse () {}
@@ -195,7 +195,7 @@ function instrumentHttp (build, run, options, res) {
 function instrument (span, run, options, callback) {
   // Verify that a run function is given
   if (typeof run !== 'function') {
-    ao.loggers.error(`ao.instrument() run function is ${typeof run}`)
+    apm.loggers.error(`apm.instrument() run function is ${typeof run}`)
     return
   }
 
@@ -213,7 +213,7 @@ function instrument (span, run, options, callback) {
       callback = function () {}
     }
   } catch (e) {
-    ao.loggers.error('ao.instrument failed to normalize arguments', e.stack)
+    apm.loggers.error('apm.instrument failed to normalize arguments', e.stack)
   }
 
   return run(callback)
@@ -256,7 +256,7 @@ function reportInfo (data) {
 }
 
 function sendMetrics (metrics) {
-  return aob.Reporter.sendMetrics(metrics)
+  return apmb.Reporter.sendMetrics(metrics)
 }
 
 function getTraceObjectForLog () {

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,8 +2,8 @@
 
 const shimmer = require('shimmer')
 
-let ao
-let aob
+let apm
+let apmb
 let cls
 let log
 let Event
@@ -16,13 +16,13 @@ let dbSettingsError
 const udp = process.env.SW_APM_REPORTER === 'udp'
 
 module.exports = function (agent) {
-  ao = agent
-  aob = ao.addon
-  cls = ao.cls
-  log = ao.loggers
+  apm = agent
+  apmb = apm.addon
+  cls = apm.cls
+  log = apm.loggers
 
   // define the properties (some of which are part of the API)
-  definePropertiesOn(ao)
+  definePropertiesOn(apm)
 
   // create the debounced loggers
   dbBind = new log.Debounce('bind')
@@ -30,14 +30,14 @@ module.exports = function (agent) {
   dbSettingsError = new log.Debounce('error')
 
   // keep weakmap references in a central place.
-  ao.maps.responseIsPatched = responseIsPatched
-  ao.maps.responseFinalizers = responseFinalizers
+  apm.maps.responseIsPatched = responseIsPatched
+  apm.maps.responseFinalizers = responseFinalizers
 
   // each invocation in lambda is counted
   // use property check that does not trigger node 14 warning on
   // non-existent property in unfinished module.exports
-  if (Object.prototype.hasOwnProperty.call(ao, 'lambda')) {
-    ao.lambda.invocations = 0
+  if (Object.prototype.hasOwnProperty.call(apm, 'lambda')) {
+    apm.lambda.invocations = 0
   }
 
   // make these globally available.
@@ -89,23 +89,23 @@ module.exports = function (agent) {
 let traceMode
 let sampleRate
 
-function definePropertiesOn (ao) {
+function definePropertiesOn (apm) {
   /**
    * Get and set the trace mode
    *
-   * @name ao.traceMode
+   * @name apm.traceMode
    * @property {string} - the sample mode
    */
-  Object.defineProperty(ao, 'traceMode', {
-    get () { return ao.modeToStringMap[traceMode] },
+  Object.defineProperty(apm, 'traceMode', {
+    get () { return apm.modeToStringMap[traceMode] },
     set (value) {
-      if (!(value in ao.modeMap)) {
+      if (!(value in apm.modeMap)) {
         log.error('invalid traceMode', value)
         return
       }
       log.info('setting traceMode to ' + value)
-      value = ao.modeMap[value]
-      aob.Settings.setTracingMode(value)
+      value = apm.modeMap[value]
+      apmb.Settings.setTracingMode(value)
       traceMode = value
     }
   })
@@ -115,14 +115,14 @@ function definePropertiesOn (ao) {
    * Get and set the sample rate. The number is parts of 1,000,000
    * so 100,000 represents a 10% sample rate.
    *
-   * @name ao.sampleRate
+   * @name apm.sampleRate
    * @property {number} - this value divided by 1000000 is the sample rate.
    */
-  Object.defineProperty(ao, 'sampleRate', {
+  Object.defineProperty(apm, 'sampleRate', {
     get () { return sampleRate },
     set (value) {
       log.info('set sample rate to ' + value)
-      const rateUsed = aob.Settings.setDefaultSampleRate(value)
+      const rateUsed = apmb.Settings.setDefaultSampleRate(value)
       if (rateUsed !== value && value !== -1) {
         if (rateUsed === -1) {
           // value was not a valid number, don't use it
@@ -139,34 +139,34 @@ function definePropertiesOn (ao) {
   /**
    * Return whether or not the current code path is being traced.
    *
-   * @name ao.tracing
+   * @name apm.tracing
    * @property {boolean}
    * @readOnly
    */
-  Object.defineProperty(ao, 'tracing', {
-    get () { return !!ao.lastEvent }
+  Object.defineProperty(apm, 'tracing', {
+    get () { return !!apm.lastEvent }
   })
 
   /**
    * Get X-Trace ID of the last event
    *
-   * @name ao.traceId
+   * @name apm.traceId
    * @property {string} - the trace ID as a string or undefined if not tracing.
    * @readOnly
    */
-  Object.defineProperty(ao, 'traceId', {
+  Object.defineProperty(apm, 'traceId', {
     get () {
-      const last = ao.lastEvent
+      const last = apm.lastEvent
       if (last) return last.toString()
     }
   })
 
   const asyncHooks = require('async_hooks')
-  Object.defineProperty(ao, 'lastEvent', {
+  Object.defineProperty(apm, 'lastEvent', {
     get () {
       let last
       try {
-        last = ao.requestStore.get('lastEvent')
+        last = apm.requestStore.get('lastEvent')
       } catch (e) {
         // avoid logging during node bootstrap phase. https://nodejs.org/api/async_hooks.html.
         if (asyncHooks.executionAsyncId() !== 1) {
@@ -177,18 +177,18 @@ function definePropertiesOn (ao) {
     },
     set (value) {
       try {
-        ao.requestStore.set('lastEvent', value)
+        apm.requestStore.set('lastEvent', value)
       } catch (e) {
         log.error('Can not set lastEvent. Context may be lost.')
       }
     }
   })
 
-  Object.defineProperty(ao, 'lastSpan', {
+  Object.defineProperty(apm, 'lastSpan', {
     get () {
       let last
       try {
-        last = ao.requestStore.get('lastSpan')
+        last = apm.requestStore.get('lastSpan')
       } catch (e) {
         // avoid logging during node bootstrap phase. https://nodejs.org/api/async_hooks.html.
         if (asyncHooks.executionAsyncId() !== 1) {
@@ -199,7 +199,7 @@ function definePropertiesOn (ao) {
     },
     set (value) {
       try {
-        ao.requestStore.set('lastSpan', value)
+        apm.requestStore.set('lastSpan', value)
       } catch (e) {
         log.error('Can not set lastSpan. Context may be lost.')
       }
@@ -207,14 +207,14 @@ function definePropertiesOn (ao) {
   })
 
   const maps = Object.create(null)
-  Object.defineProperty(ao, 'maps', {
+  Object.defineProperty(apm, 'maps', {
     get () { return maps }
   })
 
   // this being defined is shorthand for being executed in a lambda environment.
-  if (ao.execEnv.id === 'lambda') {
+  if (apm.execEnv.id === 'lambda') {
     const lambda = {}
-    Object.defineProperty(ao, 'lambda', {
+    Object.defineProperty(apm, 'lambda', {
       get () { return lambda }
     })
   }
@@ -224,11 +224,11 @@ function definePropertiesOn (ao) {
   // from jeff-lewis' cls-hooked which was derived from forrest norvell's
   // continuation-local-storage.
   //
-  const contextName = 'ao-cls-context'
+  const contextName = 'apm-cls-context'
   const clsOpts = { captureHooks: false }
 
   let aceContext
-  Object.defineProperty(ao, 'requestStore', {
+  Object.defineProperty(apm, 'requestStore', {
     get () {
       if (aceContext) {
         return aceContext
@@ -237,13 +237,13 @@ function definePropertiesOn (ao) {
     }
   })
 
-  ao.resetRequestStore = function resetRequestStore (options) {
+  apm.resetRequestStore = function resetRequestStore (options) {
     cls.destroyNamespace(contextName)
     aceContext = cls.createNamespace(contextName, options || clsOpts)
   }
 
-  ao.clsCheck = function clsCheck (msg) {
-    const c = ao.requestStore
+  apm.clsCheck = function clsCheck (msg) {
+    const c = apm.requestStore
     const ok = c && c.active
     if (msg) {
       log.debug('CLS%s %s', ok ? '' : ' NOT ACTIVE', msg)
@@ -252,12 +252,12 @@ function definePropertiesOn (ao) {
   }
 
   //
-  // ao.stack - generate a stack trace with the call to this function removed
+  // apm.stack - generate a stack trace with the call to this function removed
   //
   // text - used as Error(text)
   // n - the depth of the stack trace to generate.
   //
-  ao.stack = function stack (text, n) {
+  apm.stack = function stack (text, n) {
     const original = Error.stackTraceLimit
     // increase the stackTraceLimit by one so this function call
     // can be removed.
@@ -277,10 +277,10 @@ function definePropertiesOn (ao) {
   /**
    * Generate a backtrace string
    *
-   * @method ao.backtrace
+   * @method apm.backtrace
    * @returns {string} the backtrace
    */
-  ao.backtrace = function backtrace () {
+  apm.backtrace = function backtrace () {
     const e = new Error('backtrace')
     return e.stack.replace(/[^\n]*\n\s+/, '').replace(/\n\s*/g, '\n')
   }
@@ -288,27 +288,27 @@ function definePropertiesOn (ao) {
   /**
    * Bind a function to the CLS context if tracing.
    *
-   * @method ao.bind
+   * @method apm.bind
    * @param {function} fn - The function to bind to the context
    * @return {function} The bound function or the unmodified argument if it can't
    *   be bound.
    */
-  ao.bind = function bind (fn) {
+  apm.bind = function bind (fn) {
     try {
-      if (ao.tracing && typeof fn === 'function') {
-        return ao.requestStore.bind(fn)
+      if (apm.tracing && typeof fn === 'function') {
+        return apm.requestStore.bind(fn)
       }
 
       const name = fn ? fn.name : 'anonymous'
       // it's not quite right so issure diagnostic message
-      if (!ao.clsCheck()) {
+      if (!apm.clsCheck()) {
         const e = new Error('CLS NOT ACTIVE')
-        log.bind('ao.bind(%s) - no context', name, e.stack)
-      } else if (!ao.tracing) {
-        log.bind('ao.bind(%s) - not tracing', name)
+        log.bind('apm.bind(%s) - no context', name, e.stack)
+      } else if (!apm.tracing) {
+        log.bind('apm.bind(%s) - not tracing', name)
       } else if (fn !== undefined) {
         const e = new Error('Not a function')
-        log.bind('ao.bind(%s) - not a function', fn, e.stack)
+        log.bind('apm.bind(%s) - not a function', fn, e.stack)
       }
     } catch (e) {
       log.error('failed to bind callback', e.stack)
@@ -321,32 +321,32 @@ function definePropertiesOn (ao) {
   /**
    * Bind an emitter if tracing
    *
-   * @method ao.bindEmitter
+   * @method apm.bindEmitter
    * @param {EventEmitter} em The emitter to bind to the trace context
    * @return {EventEmitter} The bound emitter or the original emitter if an error.
    */
-  ao.bindEmitter = function bindEmitter (em) {
+  apm.bindEmitter = function bindEmitter (em) {
     let emitter = false
     try {
       if (em && typeof em.on === 'function') {
         emitter = true
         // allow binding if tracing. no last event has been setup when the
         // http instrumentation binds the events but there must be CLS context.
-        if (ao.tracing || ao.clsCheck()) {
-          ao.requestStore.bindEmitter(em)
+        if (apm.tracing || apm.clsCheck()) {
+          apm.requestStore.bindEmitter(em)
           return em
         }
       }
 
       const e = new Error('CLS NOT ACTIVE')
-      if (!ao.clsCheck()) {
-        dbBind.log('ao.bindEmitter - no context', e.stack)
-      } else if (!ao.tracing) {
-        dbInfo.log('ao.bindEmitter - not tracing')
+      if (!apm.clsCheck()) {
+        dbBind.log('apm.bindEmitter - no context', e.stack)
+      } else if (!apm.tracing) {
+        dbInfo.log('apm.bindEmitter - not tracing')
       } else if (!emitter) {
-        dbBind.log('ao.bindEmitter - non-emitter', e.stack)
+        dbBind.log('apm.bindEmitter - non-emitter', e.stack)
       } else {
-        dbBind.log('ao.bindEmitter - couldn\'t bind emitter')
+        dbBind.log('apm.bindEmitter - couldn\'t bind emitter')
       }
     } catch (e) {
       log.error('failed to bind emitter', e.stack)
@@ -360,7 +360,7 @@ function definePropertiesOn (ao) {
    * Set a custom transaction name function for a specific probe. This is
    * most commonly used when setting custom names for all or most routes.
    *
-   * @method ao.setCustomTxNameFunction
+   * @method apm.setCustomTxNameFunction
    * @param {string} probe - The probe to set the function for
    * @param {function} fn - A function that returns a string custom name or a
    *                        falsey value indicating the default should be used.
@@ -372,28 +372,28 @@ function definePropertiesOn (ao) {
    * express: customFunction (req, res)
    * hapi/hapi: customFunction (request)
    */
-  ao.setCustomTxNameFunction = function setCustomTxNameFunction (probe, fn) {
+  apm.setCustomTxNameFunction = function setCustomTxNameFunction (probe, fn) {
     // if the probe exists set the function and return success
-    if (probe in ao.probes && typeof fn === 'function') {
-      ao.probes[probe].customNameFunc = fn
+    if (probe in apm.probes && typeof fn === 'function') {
+      apm.probes[probe].customNameFunc = fn
       return true
     }
     // return failure
     return false
   }
 
-  ao.wrappedFlag = Symbol('ao-wrapped')
+  apm.wrappedFlag = Symbol('apm-wrapped')
 }
 
 //= ===================================================================================
 // none of the following can be invoked before the initialization function is called
-// and sets ao.
+// and sets apm.
 //= ===================================================================================
 
 /**
  * Check whether the agent is ready to sample. It will wait up to
  * the specified number of milliseconds before returning.
- * @method ao.readyToSample
+ * @method apm.readyToSample
  * @param {Number} ms - milliseconds to wait; default 0 means don't wait (poll).
  * @param {Object} [obj] - if present obj.status will receive low level status
  * @returns {boolean} - true if ready to sample; false if not
@@ -408,7 +408,7 @@ function definePropertiesOn (ao) {
  * CONNECT_ERROR 5
  */
 function readyToSample (ms, obj) {
-  const status = aob.isReadyToSample(ms)
+  const status = apmb.isReadyToSample(ms)
   // if the caller wants the actual status provide it
   if (obj && typeof obj === 'object') {
     obj.status = status
@@ -436,7 +436,7 @@ function readyToSample (ms, obj) {
  * make an alias for what will become the new oboe sample call.
  *
  * @ignore
- * @method ao.getTraceSettings
+ * @method apm.getTraceSettings
  * @param {string} traceparent
  * @param {string} tracestate
  * @param {number} [localMode=undefined]
@@ -457,7 +457,7 @@ function getTraceSettings (traceparent, tracestate, options = {}) {
   // add options but don't allow an x-trace to be specified in options.
   settings = Object.assign(options, settings)
 
-  let osettings = aob.Settings.getTraceSettings(settings)
+  let osettings = apmb.Settings.getTraceSettings(settings)
 
   // handle this for testing as oboe doesn't set doMetrics under the UDP
   // protocol.
@@ -468,7 +468,7 @@ function getTraceSettings (traceparent, tracestate, options = {}) {
   osettings.inboundXtrace = settings.xtrace
 
   // record this for debugging purposes
-  ao.lastSettings = osettings
+  apm.lastSettings = osettings
 
   if (osettings.status > 0) {
     dbSettingsError.log(`getTraceSettings() - ${osettings.message}(${osettings.status})`)
@@ -479,7 +479,7 @@ function getTraceSettings (traceparent, tracestate, options = {}) {
       source: 5,
       rate: 0,
       edge: false,
-      metadata: aob.Event.makeRandom(0)
+      metadata: apmb.Event.makeRandom(0)
     }, osettings)
     // if getTraceSettings() failed then don't count the x-trace even if it was valid.
     osettings.inboundXtrace = false
@@ -497,7 +497,7 @@ function getTraceSettings (traceparent, tracestate, options = {}) {
  * Determine if the sample flag is set for the various forms of
  *  data.
  *
- * @method ao.sampling
+ * @method apm.sampling
  * @param {string|Event|addon.Event} item - the item to get the sampling flag of
  * @returns {boolean} - true if the sample flag is set else false.
  */
@@ -511,7 +511,7 @@ function sampling (item) {
     return item.event.getSampleFlag()
   }
 
-  if (item instanceof aob.Event) {
+  if (item instanceof apmb.Event) {
     return item.getSampleFlag()
   }
 
@@ -521,7 +521,7 @@ function sampling (item) {
 /**
  * Convert an traceparent ID to an event containing the task ID and op ID.
  *
- * @method ao.traceToEvent
+ * @method apm.traceToEvent
  * @param {string} traceparent - traceparent ID
  * @return {addon.Event|undefined} - addon.Event object
  *                                      containing an internal
@@ -530,14 +530,14 @@ function sampling (item) {
  *                                      if not.
  */
 function traceToEvent (traceparent) {
-  return aob.Event.makeFromString(traceparent)
+  return apmb.Event.makeFromString(traceparent)
 }
 
 /**
- * Patch an HTTP response object to trigger ao-response-end events
+ * Patch an HTTP response object to trigger apm-response-end events
  *
  * @ignore
- * @method ao.patchResponse
+ * @method apm.patchResponse
  * @param {HTTPResponse} res HTTP Response object
  */
 const responseIsPatched = new WeakMap()
@@ -564,7 +564,7 @@ function patchResponse (res) {
  * Add a finalizer to trigger when the response ends
  *
  * @ignore
- * @method ao.addResponseFinalizer
+ * @method apm.addResponseFinalizer
  * @param {HTTPResponse} res - HTTP Response to attach a finalizer to
  * @param {function} finalizer - Finalization function
  */
@@ -592,7 +592,7 @@ function addResponseFinalizer (res, finalizer) {
 /**
  * Instrument HTTP request/response
  *
- * @method ao.instrumentHttp
+ * @method apm.instrumentHttp
  * @param {string|spanInfoFunction} span - name or function returning spanInfo
  * @param {function} run - code to instrument and run
  * @param {object} [options] - options
@@ -603,13 +603,13 @@ function addResponseFinalizer (res, finalizer) {
  */
 function instrumentHttp (build, run, options, res) {
   // If not tracing, skip
-  const last = ao.lastSpan
+  const last = apm.lastSpan
   if (!last) {
-    ao.loggers.warn('instrumentHttp: no last span')
+    apm.loggers.warn('instrumentHttp: no last span')
     return run()
   }
   if ('enabled' in options && !options.enabled) {
-    ao.loggers.info('instrumentHttp: disabled by option')
+    apm.loggers.info('instrumentHttp: disabled by option')
     return run()
   }
 
@@ -630,7 +630,7 @@ function instrumentHttp (build, run, options, res) {
 
     // attach backtrace if this trace is sampled and configured.
     if (options.collectBacktraces && last.doSample) {
-      kvpairs.Backtrace = ao.backtrace(4)
+      kvpairs.Backtrace = apm.backtrace(4)
     }
     span = last.descend(name, kvpairs)
 
@@ -638,31 +638,31 @@ function instrumentHttp (build, run, options, res) {
       finalize(span, last)
     }
   } catch (e) {
-    ao.loggers.error('instrumentHttp failed to build span %s', e.stack)
+    apm.loggers.error('instrumentHttp failed to build span %s', e.stack)
   }
 
   let ctx
   try {
     if (span && span.topSpan) {
-      ctx = ao.requestStore.createContext()
-      ao.requestStore.enter(ctx)
+      ctx = apm.requestStore.createContext()
+      apm.requestStore.enter(ctx)
     }
   } catch (e) {
-    ao.loggers.error('instrumentHttp failed to enter span %l', span)
+    apm.loggers.error('instrumentHttp failed to enter span %l', span)
   }
 
   if (span) {
     span.enter()
-    ao.addResponseFinalizer(res, ao.bind(() => {
+    apm.addResponseFinalizer(res, apm.bind(() => {
       span.exit()
       try {
         if (ctx) {
-          ao.requestStore.exit(ctx)
+          apm.requestStore.exit(ctx)
         } else if (span.topSpan) {
-          ao.loggers.error('no context for topSpan')
+          apm.loggers.error('no context for topSpan')
         }
       } catch (e) {
-        ao.loggers.error('instrumentHttp failed to exit span %l', span)
+        apm.loggers.error('instrumentHttp failed to exit span %l', span)
       }
     }))
   }
@@ -678,7 +678,7 @@ function instrumentHttp (build, run, options, res) {
 /**
  * Apply custom instrumentation to a synchronous or async-callback function.
  *
- * @method ao.instrument
+ * @method apm.instrument
  * @param {string|spanInfoFunction} span - span name or span-info function
  *     If `span` is a string then a span is created with that name. If it
  *     is a function it will be run only if tracing; it must return a
@@ -718,7 +718,7 @@ function instrumentHttp (build, run, options, res) {
  *   // do things with contents
  * }
  *
- * ao.instrument(spanInfo, run)
+ * apm.instrument(spanInfo, run)
  *
  * @example
  * //
@@ -744,12 +744,12 @@ function instrumentHttp (build, run, options, res) {
  *   console.log('file contents are: ' + data)
  * }
  *
- * ao.instrument(spanInfo, run, callback)
+ * apm.instrument(spanInfo, run, callback)
  */
 function instrument (span, run, options, callback) {
   // Verify that a run function is given
   if (typeof run !== 'function') {
-    ao.loggers.error(`ao.instrument() run function is ${typeof run}`)
+    apm.loggers.error(`apm.instrument() run function is ${typeof run}`)
     return
   }
 
@@ -761,7 +761,7 @@ function instrument (span, run, options, callback) {
     } else {
       if (typeof options !== 'object') {
         if (options !== undefined) {
-          ao.loggers.warn(`ao.instrument() options is ${typeof options}`)
+          apm.loggers.warn(`apm.instrument() options is ${typeof options}`)
         }
         options = {}
       }
@@ -773,27 +773,27 @@ function instrument (span, run, options, callback) {
       callback = function () {}
     }
   } catch (e) {
-    ao.loggers.error('ao.instrument failed to normalize arguments', e.stack)
+    apm.loggers.error('apm.instrument failed to normalize arguments', e.stack)
   }
 
   // in startup mode run the callback as is.
   // during startup fs probe will read multiple files of included packages
   // there is no last span for that and it should not be instrumented
-  if (ao.startup) {
+  if (apm.startup) {
     return run(callback)
   }
 
   // If not tracing, there is some error, skip.
-  const last = ao.lastSpan
+  const last = apm.lastSpan
   if (!last) {
-    ao.loggers.info('ao.instrument found no lastSpan')
+    apm.loggers.info('apm.instrument found no lastSpan')
     return run(callback)
   }
 
   // If not enabled, skip but maintain context
   if (!options.enabled) {
-    ao.loggers.info('ao.instrument disabled by option')
-    return run(ao.bind(callback))
+    apm.loggers.info('apm.instrument disabled by option')
+    return run(apm.bind(callback))
   }
 
   return runInstrument(last, span, run, options, callback)
@@ -802,7 +802,7 @@ function instrument (span, run, options, callback) {
 /**
  * Apply custom instrumentation to a promise-returning asynchronous function.
  *
- * @method ao.pInstrument
+ * @method apm.pInstrument
  * @param {string|spanInfoFunction} span - span name or span-info function
  *     If `span` is a string then a span is created with that name. If it
  *     is a function it will be run only if tracing; it must return a
@@ -833,7 +833,7 @@ function instrument (span, run, options, callback) {
  *   })
  * }
  *
- * ao.pInstrument(spanInfo, run).then(...)
+ * apm.pInstrument(spanInfo, run).then(...)
  */
 function pInstrument (name, task, options = {}) {
   if (typeof task !== 'function') {
@@ -855,11 +855,11 @@ function pInstrument (name, task, options = {}) {
     })
   }
 
-  // this needs to appear async to ao.instrument, so wrapped supplies a callback. but
+  // this needs to appear async to apm.instrument, so wrapped supplies a callback. but
   // this code doesn't have a callback because the resolution of the promise is what
   // signals the task function's completion, so no 4th argument is supplied.
   //
-  // ao.instrument returns wrapped()'s value which is the original promise
+  // apm.instrument returns wrapped()'s value which is the original promise
   // that task() returns. the resolution of the promise is the value that
   // task() resolved the promise with or a thrown error. the point of
   // wrapped() is to make the callback that results in exiting the the span before
@@ -868,12 +868,12 @@ function pInstrument (name, task, options = {}) {
 }
 
 //
-// This builds a span descending from the supplied span using the ao.instrument's arguments
+// This builds a span descending from the supplied span using the apm.instrument's arguments
 //
 function runInstrument (last, make, run, options, callback) {
   // Verify that a name or span-info function is given
   if (!~['function', 'string'].indexOf(typeof make)) {
-    ao.loggers.error('ao.runInstrument found no span name or span-info()')
+    apm.loggers.error('apm.runInstrument found no span name or span-info()')
     return run(callback)
   }
 
@@ -894,14 +894,14 @@ function runInstrument (last, make, run, options, callback) {
       span = last.descend(name, kvpairs)
     } else {
       const msg = typeof make === 'function' ? ' by span-info()' : ''
-      ao.loggers.error(`no name supplied to runInstrument${msg}`)
+      apm.loggers.error(`no name supplied to runInstrument${msg}`)
     }
 
     if (finalize) {
       finalize(span, last)
     }
   } catch (e) {
-    ao.loggers.error('ao.runInstrument failed to build span', e.stack)
+    apm.loggers.error('apm.runInstrument failed to build span', e.stack)
   }
 
   // run span
@@ -918,7 +918,7 @@ function runSpan (span, run, options, callback) {
 
   // Attach backtrace if sampling and enabled.
   if (span.doSample && options.collectBacktraces) {
-    span.events.entry.set({ Backtrace: ao.backtrace() })
+    span.events.entry.set({ Backtrace: apm.backtrace() })
   }
 
   // Detect if sync or async, and run span appropriately
@@ -938,7 +938,7 @@ function makeWrappedRunner (run, callback) {
  * trace based on an X-Trace ID received from an external source, e.g.,
  * HTTP headers or message queue headers.
  *
- * @method ao.startOrContinueTrace
+ * @method apm.startOrContinueTrace
  * @param {string} traceparent - traceparent ID to continue from or null
  * @param {string} tracestate - tracestate ID to continue from or null
  * @param {string|spanInfoFunction} span - name or function returning spanInfo
@@ -952,14 +952,14 @@ function makeWrappedRunner (run, callback) {
  * @returns {value} the value returned by the run function or undefined if it can't be run
  *
  * @example
- * ao.startOrContinueTrace(
+ * apm.startOrContinueTrace(
  *   null,
  *   'sync-span-name',
  *   functionToRun,           // synchronous so function takes no arguments
  *   {customTxName: 'special-span-name'}
  * )
  * @example
- * ao.startOrContinueTrace(
+ * apm.startOrContinueTrace(
  *   null,
  *   'sync-span-name',
  *   functionToRun,
@@ -977,7 +977,7 @@ function makeWrappedRunner (run, callback) {
  * }
  * // and realCallback is supplied as the optional callback parameter
  *
- * ao.startOrContinueTrace(
+ * apm.startOrContinueTrace(
  *   null,
  *   'async-span-name',
  *   asyncFunctionToRun,     // async, so function takes one argument
@@ -1002,7 +1002,7 @@ function startOrContinueTrace (traceparent, tracestate, build, run, opts, cb) {
       cb = function () {}
     }
   } catch (e) {
-    ao.loggers.error('ao.startOrContinueTrace can\'t normalize arguments', e.stack)
+    apm.loggers.error('apm.startOrContinueTrace can\'t normalize arguments', e.stack)
   }
 
   // verify that a span name or span-info function is provided. it is called
@@ -1013,12 +1013,12 @@ function startOrContinueTrace (traceparent, tracestate, build, run, opts, cb) {
 
   // If not enabled, skip
   if (!opts.enabled) {
-    return run(ao.bind(cb))
+    return run(apm.bind(cb))
   }
 
   // If already tracing, continue the existing trace ignoring any traceparent
   // passed as the first argument, unless forcing a new trace.
-  const last = ao.lastSpan
+  const last = apm.lastSpan
   if (last && !opts.forceNewTrace) {
     return runInstrument(last, build, run, opts, cb)
   }
@@ -1028,7 +1028,7 @@ function startOrContinueTrace (traceparent, tracestate, build, run, opts, cb) {
   try {
     settings = getTraceSettings(traceparent, tracestate)
   } catch (e) {
-    ao.loggers.error('ao.startOrContinueTrace can\'t get a sample decision', e.stack)
+    apm.loggers.error('apm.startOrContinueTrace can\'t get a sample decision', e.stack)
     settings = { doSample: false, doMetrics: false, source: 5, rate: 0 }
   }
 
@@ -1051,7 +1051,7 @@ function startOrContinueTrace (traceparent, tracestate, build, run, opts, cb) {
       finalize(span)
     }
   } catch (e) {
-    ao.loggers.error('ao.startOrContinueTrace failed to build span %s', e.stack)
+    apm.loggers.error('apm.startOrContinueTrace failed to build span %s', e.stack)
   }
 
   // if no span can't do sampling or inbound metrics - need a context.
@@ -1075,7 +1075,7 @@ function startOrContinueTrace (traceparent, tracestate, build, run, opts, cb) {
  * the sense of continuing a trace based on an X-Trace ID received from an external
  * source, e.g., HTTP headers or message queue headers.
  *
- * @method ao.pStartOrContinueTrace
+ * @method apm.pStartOrContinueTrace
  * @param {string} traceparent - traceparent ID to continue from or null
  * @param {string} tracestate - tracestate ID to continue from or null
  * @param {string|spanInfoFunction} span - name or function returning spanInfo
@@ -1102,7 +1102,7 @@ function startOrContinueTrace (traceparent, tracestate, build, run, opts, cb) {
  *   })
  * }
  *
- * ao.pStartOrContinueTrace(
+ * apm.pStartOrContinueTrace(
  *   null,
  *   spanInfo,
  *   functionToRun,
@@ -1111,7 +1111,7 @@ function startOrContinueTrace (traceparent, tracestate, build, run, opts, cb) {
 async function pStartOrContinueTrace (traceparent, tracestate, protoSpan, func, opts) {
   // Verify that a run function is given
   if (typeof func !== 'function') {
-    ao.loggers.error(`pStartOrContinueTrace requires a function, not ${typeof func}`)
+    apm.loggers.error(`pStartOrContinueTrace requires a function, not ${typeof func}`)
     return
   }
 
@@ -1128,7 +1128,7 @@ async function pStartOrContinueTrace (traceparent, tracestate, protoSpan, func, 
   // this point but both logic paths are kept here in this function.
   let last
   if (!opts.forceNewTrace) {
-    last = ao.lastSpan
+    last = apm.lastSpan
   }
 
   // get information needed for the span
@@ -1142,7 +1142,7 @@ async function pStartOrContinueTrace (traceparent, tracestate, protoSpan, func, 
       // last is defined only if there is a trace in progress AND not forcing a new trace.
       ({ name, kvpairs, finalize } = protoSpan(last))
     } catch (e) {
-      ao.loggers.debug(`span-info() failed ${e.message}`)
+      apm.loggers.debug(`span-info() failed ${e.message}`)
     }
 
     const protoSpanErrors = []
@@ -1159,11 +1159,11 @@ async function pStartOrContinueTrace (traceparent, tracestate, protoSpan, func, 
       protoSpanErrors.push('finalize function')
     }
     if (protoSpanErrors.length) {
-      ao.loggers.error(`pStartOrContinueTrace span-info bad values: ${protoSpanErrors.join(', ')}`)
+      apm.loggers.error(`pStartOrContinueTrace span-info bad values: ${protoSpanErrors.join(', ')}`)
       return func()
     }
   } else {
-    ao.loggers.error(`pStartOrContinueTrace span argument must be a string or function, not ${typeof protoSpan}`)
+    apm.loggers.error(`pStartOrContinueTrace span argument must be a string or function, not ${typeof protoSpan}`)
     return func()
   }
 
@@ -1192,14 +1192,14 @@ async function pStartOrContinueTrace (traceparent, tracestate, protoSpan, func, 
       finalize(span, last)
     }
   } catch (e) {
-    ao.loggers.error(`pStartOrContinueTrace failed to ${state}`, e.stack)
+    apm.loggers.error(`pStartOrContinueTrace failed to ${state}`, e.stack)
     return func()
   }
 
   // if no span can't do sampling or inbound metrics - need a context. is this possible if nothing in
   // the try block above fails?
   if (!span) {
-    ao.loggers.error('pStartOrContinueTrace failed to get a span, not instrumenting')
+    apm.loggers.error('pStartOrContinueTrace failed to get a span, not instrumenting')
     return func()
   }
 
@@ -1209,22 +1209,22 @@ async function pStartOrContinueTrace (traceparent, tracestate, protoSpan, func, 
 /**
  * Report an error event in the current trace.
  *
- * @method ao.reportError
+ * @method apm.reportError
  * @param {Error} error - The error instance to report
  */
 function reportError (error) {
-  const last = ao.lastSpan
+  const last = apm.lastSpan
   if (last) last.error(error)
 }
 
 /**
  * Report an info event in the current trace.
  *
- * @method ao.reportInfo
+ * @method apm.reportInfo
  * @param {object} data - Data to report in the info event
  */
 function reportInfo (data) {
-  const last = ao.lastSpan
+  const last = apm.lastSpan
   if (last) last.info(data)
 }
 
@@ -1277,7 +1277,7 @@ function reportInfo (data) {
  * The metrics submitted are aggregated by metric name and tag(s), then
  * sent every 60 seconds.
  *
- * @method ao.sendMetrics
+ * @method apm.sendMetrics
  * @param {(metric|metric[])} metrics - a metric or an array of metrics
  * @param {object} [gopts] - supply defaults to be applied to each metric.
  * @param {boolean} [gopts.addHostTag=false] - add a hostname tag
@@ -1289,11 +1289,11 @@ function reportInfo (data) {
  * @example
  *
  * // send a single metric
- * ao.sendMetrics({name: 'my.counts.basic'});
- * ao.sendMetrics({name: 'my.values.some', value: 42.42});
+ * apm.sendMetrics({name: 'my.counts.basic'});
+ * apm.sendMetrics({name: 'my.values.some', value: 42.42});
  *
  * // send multiple metrics (most efficient)
- * ao.sendMetrics([
+ * apm.sendMetrics([
  *   // default count is 1
  *   {name: 'my.counts.defaulted'},
  *   {name: 'my.counts.multiple', count: 3},
@@ -1303,17 +1303,17 @@ function reportInfo (data) {
  * ]);
  *
  * // add tags that can be used for filtering on the host
- * ao.sendMetrics([
+ * apm.sendMetrics([
  *   {name: 'my.metric.end-of-file', tags: {class: 'error', subsystem: 'fs'}}
  * ]);
  *
  * // add a hostname tag automatically.
- * ao.sendMetrics([
+ * apm.sendMetrics([
  *   {name: 'my.metric.end-of-file', tags: {class: 'error'}, addHostTag: true}
  * ]);
  *
  * // add a hostname tag and an application tag to each metric.
- * ao.sendMetrics(
+ * apm.sendMetrics(
  *   [
  *     {name: 'my.metric', tags: {class: 'status'}},
  *     {name: 'my.time', value: 33.3, tags: {class: 'performance'}}
@@ -1323,7 +1323,7 @@ function reportInfo (data) {
  *
  * // default class to 'status' for metrics that don't supply a class
  * // tag.
- * ao.sendMetrics(
+ * apm.sendMetrics(
  *   [
  *     {name: 'my.metric'},
  *     {name: 'my.time', value: 33.3, tags: {class: 'performance'}}
@@ -1349,21 +1349,21 @@ function sendMetrics (metrics, gopts = {}) {
     merged.push(metric)
   }
 
-  return aob.Reporter.sendMetrics(merged)
+  return apmb.Reporter.sendMetrics(merged)
 }
 
 /**
  * Return an object representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
  * to insert custom tokens in log packages.
  *
- * @method ao.getTraceObjectForLog
+ * @method apm.getTraceObjectForLog
  * @returns {object} - the trace log  object (e.g. { trace_id:..., span_id: ..., trace_flages: ...})
 
  * @example
  *
  * log4js.addLayout('json', function (config) {
  *   return function (logEvent) {
- *     logEvent.context = { ...logEvent.context, ...ao.getTraceObjectForLog() }
+ *     logEvent.context = { ...logEvent.context, ...apm.getTraceObjectForLog() }
  *     return JSON.stringify(logEvent)
  *   }
  * })
@@ -1383,8 +1383,8 @@ function getTraceObjectForLog () {
   // if truthy and tracing insert it based on sample setting. otherwise if 'always'
   // then insert a trace ID regardless. No explicit check for 'traced' is required.
   let last
-  if ((ao.cfg.insertTraceIdsIntoLogs) && (last = ao.lastEvent)) {
-    if (ao.cfg.insertTraceIdsIntoLogs !== 'sampledOnly' || last.event.getSampleFlag()) {
+  if ((apm.cfg.insertTraceIdsIntoLogs) && (last = apm.lastEvent)) {
+    if (apm.cfg.insertTraceIdsIntoLogs !== 'sampledOnly' || last.event.getSampleFlag()) {
       const parts = last.toString().split('-')
       return {
         trace_id: parts[1],
@@ -1392,7 +1392,7 @@ function getTraceObjectForLog () {
         trace_flags: parts[3]
       }
     }
-  } else if (ao.cfg.insertTraceIdsIntoLogs === 'always') {
+  } else if (apm.cfg.insertTraceIdsIntoLogs === 'always') {
     return {
       trace_id: '0'.repeat(32),
       span_id: '0'.repeat(16),
@@ -1406,7 +1406,7 @@ function getTraceObjectForLog () {
  * Return text delimited representation of the trace containing trace_id, span_id, trace_flags. The primary intended use for this is
  * to insert custom tokens in log packages.
  *
- * @method ao.getTraceStringForLog
+ * @method apm.getTraceStringForLog
  * @param {string} [delimiter] - the delimiter to use
  *
  * @returns {string} - the trace log string (e.g. trace_id:... span_id: ..., trace_flages: ...)
@@ -1424,7 +1424,7 @@ function getTraceObjectForLog () {
  *             return 'Jake'
  *           },
  *           trace: function () {
- *             return typeof ao !=='undefined' ? ao.getTraceStringForLog() : ''
+ *             return typeof apm !=='undefined' ? apm.getTraceStringForLog() : ''
  *           }
  *         }
  *       }
@@ -1436,14 +1436,14 @@ function getTraceObjectForLog () {
  * logger.info('token from api')
  */
 function getTraceStringForLog (delimiter = ' ') {
-  const obj = ao.getTraceObjectForLog()
+  const obj = apm.getTraceObjectForLog()
   return obj ? Object.entries(obj).map(([k, v]) => `${k}=${v}`).join(delimiter) : ''
 }
 
 /**
  * Wrap the lambda handler function so it can be traced by AppOptics APM.
  *
- * @method ao.wrapLambdaHandler
+ * @method apm.wrapLambdaHandler
  * @param {function} [handler] - wraps your lambda handler function so it
  *                               is instrumented. your handler must return
  *                               a promise, be a JavaScript async function,
@@ -1452,9 +1452,9 @@ function getTraceStringForLog (delimiter = ' ') {
  *                       instead of handler.
  *
  * @example
- * const ao = require('appoptics-apm');
+ * const apm = require('appoptics-apm');
  *
- * const wrappedHandler = ao.wrapLambdaHandler(myHandler);
+ * const wrappedHandler = apm.wrapLambdaHandler(myHandler);
  *
  * async function myHandler (event, context) {
  *   // implementation
@@ -1465,9 +1465,9 @@ function getTraceStringForLog (delimiter = ' ') {
  * exports.handler = wrappedHandler;
  *
  * @example
- * const ao = require('appoptics-apm');
+ * const apm = require('appoptics-apm');
  *
- * const wrappedHandler = ao.wrapLambdaHandler(myHandler);
+ * const wrappedHandler = apm.wrapLambdaHandler(myHandler);
  *
  * function myHandler (event, context, callback) {
  *   // implementation
@@ -1480,9 +1480,9 @@ function getTraceStringForLog (delimiter = ' ') {
  * }
  */
 function wrapLambdaHandler (userHandler) {
-  if (userHandler[ao.wrappedFlag]) {
+  if (userHandler[apm.wrappedFlag]) {
     log.debug('already wrapped')
-    return userHandler[ao.wrappedFlag]
+    return userHandler[apm.wrappedFlag]
   }
 
   const wrappedFunction = async function (event, context) {
@@ -1490,8 +1490,8 @@ function wrapLambdaHandler (userHandler) {
     // dynamically. if it was disabled at startup then enabling it won't
     // cause traces because many pieces were not loaded at startup. disabling
     // it will stop traces from starting if it was enabled at startup.
-    if (!ao.cfg.enabled || !ao.lambda) {
-      log.debug(`not wrapping function: ${ao.cfg.enabled ? 'not in lambda' : 'disabled'}`)
+    if (!apm.cfg.enabled || !apm.lambda) {
+      log.debug(`not wrapping function: ${apm.cfg.enabled ? 'not in lambda' : 'disabled'}`)
       return userHandler.apply(null, arguments)
     }
 
@@ -1572,7 +1572,7 @@ function wrapLambdaHandler (userHandler) {
     )
   }
 
-  userHandler[ao.wrappedFlag] = wrappedFunction
+  userHandler[apm.wrappedFlag] = wrappedFunction
 
   return wrappedFunction
 }
@@ -1631,7 +1631,7 @@ function getTraceContext (headers) {
   if (typeof headers.traceparent !== 'string') {
     return undefined
   }
-  if (ao.traceToEvent(headers.traceparent)) {
+  if (apm.traceToEvent(headers.traceparent)) {
     return headers.traceparent
   }
 
@@ -1641,7 +1641,7 @@ function getTraceContext (headers) {
 function makeLambdaKVPairs (topSpanType, event, context) {
   const kvpairs = {
     Spec: topSpanType !== 'lambda-generic' ? 'aws-lambda:ws' : 'aws-lambda',
-    InvocationCount: ao.lambda.invocations
+    InvocationCount: apm.lambda.invocations
   }
 
   // map context property names to KV names. any values that can be

--- a/lib/event.js
+++ b/lib/event.js
@@ -4,8 +4,8 @@
 {
 const util = require('util')
 
-let ao
-let aob
+let apm
+let apmb
 let log
 
 const unsentEvents = undefined // Map() for debugging
@@ -22,7 +22,7 @@ const stats = {
  * @class Event
  * @param {string} span name of the event's span
  * @param {string} label Event label (usually entry or exit)
- * @param {aob.Event} parent supplies the taskId to construct the event from.
+ * @param {apmb.Event} parent supplies the taskId to construct the event from.
  * @param {boolean} edge This should edge back to the parent
  */
 function Event (span, label, parent, edge) {
@@ -41,9 +41,9 @@ function Event (span, label, parent, edge) {
   // in that case "edge" is false.
 
   // create event inheriting the task id from parent.
-  const event = new aob.Event(parent, !!edge)
+  const event = new apmb.Event(parent, !!edge)
 
-  // aob.Event() will add an edge to the parent if edge is true.
+  // apmb.Event() will add an edge to the parent if edge is true.
   if (edge) {
     log.event.edge('%e added edge %e', this, parent)
   }
@@ -147,8 +147,8 @@ Object.defineProperty(Event.prototype, 'opId', {
   }
 })
 
-const getEvent = util.deprecate(() => ao.lastEvent, 'use ao.lastEvent instead of Event.last')
-const setEvent = util.deprecate(event => ao.lastEvent = event, 'use ao.lastEvent instead of Event.last') // eslint-disable-line no-return-assign
+const getEvent = util.deprecate(() => apm.lastEvent, 'use apm.lastEvent instead of Event.last')
+const setEvent = util.deprecate(event => apm.lastEvent = event, 'use apm.lastEvent instead of Event.last') // eslint-disable-line no-return-assign
 
 Object.defineProperty(Event, 'last', {
   get: getEvent,
@@ -171,7 +171,7 @@ Event.prototype.set = function (data) {
       this.error = data[k]
     } else {
       const type = Number.isNaN(data[k]) ? 'NaN' : typeof data[k]
-      const stack = ao.stack(`Invalid type for KV ${k}: ${type}`)
+      const stack = apm.stack(`Invalid type for KV ${k}: ${type}`)
       log.error(stack)
     }
   }
@@ -222,10 +222,10 @@ Event.prototype.sendReport = function (data) {
   // last event.
   if (!this.ignore) {
     log.event.enter('setting last event to: %e', this)
-    ao.lastEvent = this
+    apm.lastEvent = this
   }
 
-  // if not sampling return now that ao.lastEvent has been set (unless ignored).
+  // if not sampling return now that apm.lastEvent has been set (unless ignored).
   if (!this.event.getSampleFlag()) {
     log.event.enter('not sampling so not sending %e', this)
     return
@@ -324,12 +324,12 @@ Event.prototype.addKvPairs = function () {
   }
 }
 
-Event.init = function (populatedAo) {
-  ao = populatedAo
-  ao._stats.event = stats
-  ao._stats.unsentEvents = unsentEvents
-  aob = ao.addon
-  log = ao.loggers
+Event.init = function (populatedapm) {
+  apm = populatedapm
+  apm._stats.event = stats
+  apm._stats.unsentEvents = unsentEvents
+  apmb = apm.addon
+  log = apm.loggers
 
   log.addGroup({
     groupName: 'event',

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -126,10 +126,10 @@ function getUnifiedConfig () {
 
   // get the environment variables. known keys will be removed after processing so
   // those that remain are unknown.
-  const aoKeys = {}
+  const apmKeys = {}
   for (const k in process.env) {
     if (k.startsWith('SW_APM_') && !k.startsWith('SW_APM_TEST')) {
-      aoKeys[k] = process.env[k]
+      apmKeys[k] = process.env[k]
     }
   }
 
@@ -141,7 +141,7 @@ function getUnifiedConfig () {
     file: configFile, // return the resolved path
     global: {},
     unusedConfig: fileGlobalConfig, // parts of the configuration file that weren't used
-    unusedEnvVars: aoKeys,
+    unusedEnvVars: apmKeys,
     probes: {},
     unusedProbes: fileProbesConfig, // probes in the configuration file that weren't used
     transactionSettings: undefined,
@@ -193,7 +193,7 @@ function getUnifiedConfig () {
 
     // if the environment variable exists, honor it if possible. if it doesn't
     // exist see if a default exists for the setting.
-    if (envVar in aoKeys) {
+    if (envVar in apmKeys) {
       // if the setting is restricted to a specific execution environment
       // then skip it if wrong environment.
       if (setting.eeid && setting.eeid !== execEnv.id) {
@@ -203,21 +203,21 @@ function getUnifiedConfig () {
       if (setting.ignore) {
         if (typeof setting.ignore !== 'function' || setting.ignore()) {
           debuggings.push(`guc ignoring ${envVar}`)
-          delete aoKeys[envVar]
+          delete apmKeys[envVar]
           return
         }
       }
-      const value = convert(aoKeys[envVar], setting.type)
+      const value = convert(apmKeys[envVar], setting.type)
       if (value !== undefined) {
         results.global[setting.map || k] = value
       } else {
-        warnings.push(`invalid environment variable value ${envVar}=${aoKeys[envVar]}`)
+        warnings.push(`invalid environment variable value ${envVar}=${apmKeys[envVar]}`)
       }
       if (setting.deprecated) {
         warnings.push(`${envVar} is deprecated; it will be invalid in the future`)
       }
       // remove this key because the env var is valid even if the value wasn't.
-      delete aoKeys[envVar]
+      delete apmKeys[envVar]
     }
   })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // create or get this symbol.
-const aoOnce = Symbol.for('SolarWinds.Apm.Once')
+const apmOnce = Symbol.for('SolarWinds.Apm.Once')
 
 // remember these before we've required any files so a warning can be issued if needed.
 // filter out this file and the script entry script loaded when the Node.js process launched,
@@ -12,65 +12,65 @@ const alreadyLoaded = Object.keys(require.cache).filter(f => f !== __filename &&
 // to exports (the bottom of the file in the else). This exists
 // to prevent problems with the request package which uses
 // stealthy-require to brute force multiple instantiations.
-if (global[aoOnce]) {
-  module.exports = global[aoOnce]
+if (global[apmOnce]) {
+  module.exports = global[apmOnce]
   module.exports.loggers.warn('solarwinds-apm is being executed more than once')
 } else {
 /* eslint-disable indent */
 // disable eslint's indent so it doesn't complain because everything in the else
 // (all of the file when it's required the first time) isn't indented.
 
-// make global context object with noop testing function. ao.g.testing() is
+// make global context object with noop testing function. apm.g.testing() is
 // setup differently for tests but this allows a single test to run without
 // error.
 
-const ao = exports
+const apm = exports
 
 // global place to store stats. each module should create a separate
-// namespace for its stats. e.g., ao._stats.span = {...}
-ao._stats = {}
+// namespace for its stats. e.g., apm._stats.span = {...}
+apm._stats = {}
 
-ao.version = require('../package.json').version
+apm.version = require('../package.json').version
 
-ao.g = {
+apm.g = {
   testing: function (filename) {
-    ao.g.current = filename
+    apm.g.current = filename
   },
   taskDict: {}
 }
 
 /**
- * @class ao
+ * @class apm
  *
  * @example
- * The name ao can be any name you choose. Just require
- * solarwinds-apm. In this document ao is used.
+ * The name apm can be any name you choose. Just require
+ * solarwinds-apm. In this document apm is used.
  *
- * const ao = require('solarwinds-apm')
+ * const apm = require('solarwinds-apm')
  */
 
 // first, set up logging so problems can be reported.
 const path = require('path')
 const env = process.env
 
-ao.root = path.resolve(__dirname, '..')
+apm.root = path.resolve(__dirname, '..')
 
 // don't insert traceparent/tracestate into outbound http request headers when this property is truthy.
-ao.omitTraceId = Symbol('ao.omitTraceId')
+apm.omitTraceId = Symbol('apm.omitTraceId')
 
 const { logger, loggers } = require('./loggers')
-ao.logger = logger
-const log = ao.loggers = loggers
+apm.logger = logger
+const log = apm.loggers = loggers
 
 /**
- * @name ao.logLevel
+ * @name apm.logLevel
  * @property {string} - comma separated list of log settings
  * @example <caption>Sets the log settings</caption>
- * ao.logLevel = 'warn,error'
+ * apm.logLevel = 'warn,error'
  * @example <caption>Get the log settings</caption>
- * var settings = ao.logLevel
+ * var settings = apm.logLevel
  */
-Object.defineProperty(ao, 'logLevel', {
+Object.defineProperty(apm, 'logLevel', {
   get () { return logger.logLevel },
   set (value) { logger.logLevel = value }
 })
@@ -78,28 +78,28 @@ Object.defineProperty(ao, 'logLevel', {
 /**
  * Add log levels to the existing set of log levels.
  *
- * @method ao.logLevelAdd
+ * @method apm.logLevelAdd
  * @param {string} levels - comma separated list of levels to add
  * @return {string|undefined} - the current log levels or undefined if an error
  *
  * @example
- * ao.logLevelAdd('warn,debug')
+ * apm.logLevelAdd('warn,debug')
  */
-ao.logLevelAdd = logger.addEnabled.bind(logger)
+apm.logLevelAdd = logger.addEnabled.bind(logger)
 
 /**
  * Remove log levels from the current set.
  *
- * @method ao.logLevelRemove
+ * @method apm.logLevelRemove
  * @param {string} levels - comma separated list of levels to remove
  * @return {string|undefined} - log levels after removals or undefined if an
  *                              error.
  * @example
- * var previousLogLevel = ao.logLevel
- * ao.logLevelAdd('debug')
- * ao.logLevelRemove(previousLogLevel)
+ * var previousLogLevel = apm.logLevel
+ * apm.logLevelAdd('debug')
+ * apm.logLevelRemove(previousLogLevel)
  */
-ao.logLevelRemove = logger.removeEnabled.bind(logger)
+apm.logLevelRemove = logger.removeEnabled.bind(logger)
 
 // read the config file so that if it disables the agent it's possible to
 // skip loading the bindings.
@@ -135,14 +135,14 @@ for (let i = 0; i < uc.settingsErrors.length; i++) {
 //
 // put in their historical variables.
 //
-ao.probes = uc.probes
-ao.specialUrls = uc.transactionSettings && uc.transactionSettings.filter(s => s.type === 'url')
-ao.execEnv = uc.execEnv
+apm.probes = uc.probes
+apm.specialUrls = uc.transactionSettings && uc.transactionSettings.filter(s => s.type === 'url')
+apm.execEnv = uc.execEnv
 const config = uc.global
-ao.cfg = Object.assign({}, config)
+apm.cfg = Object.assign({}, config)
 
 // now that the config is known warn about files already being required if this is not development environment.
-if (alreadyLoaded.length && ao.execEnv.nodeEnv !== 'development') {
+if (alreadyLoaded.length && apm.execEnv.nodeEnv !== 'development') {
   log.warn('the following files were loaded before solarwinds-apm:', alreadyLoaded)
 }
 
@@ -150,7 +150,7 @@ if (alreadyLoaded.length && ao.execEnv.nodeEnv !== 'development') {
 // there isn't really a better place to put this
 // it takes an http request object argument.
 //
-ao.getDomainPrefix = function (req) {
+apm.getDomainPrefix = function (req) {
   const h = req.headers
   const s = req.socket || { localPort: 80 }
   let prefix = (h && h['x-forwarded-host']) || h.host || ''
@@ -171,7 +171,7 @@ ao.getDomainPrefix = function (req) {
 // Utility function to create function that issues consistently formatted
 // messages for patching errors.
 //
-ao.makeLogMissing = function makeLogMissing (name) {
+apm.makeLogMissing = function makeLogMissing (name) {
   const s = `probes.${name} "%s" not found`
   return function logMissing (missing) {
     log.patching(s, missing)
@@ -193,7 +193,7 @@ if (!enabled) {
 
 // if the serviceKey is not valid then the agent cannot be enabled unless
 // running in AWS lambda.
-if (ao.execEnv.type !== 'serverless' || ao.execEnv.id !== 'lambda') {
+if (apm.execEnv.type !== 'serverless' || apm.execEnv.id !== 'lambda') {
   enabled = enabled && config.serviceKey
 }
 
@@ -201,13 +201,13 @@ if (ao.execEnv.type !== 'serverless' || ao.execEnv.id !== 'lambda') {
 // map valid modes to oboe values for an easy way to validate/convert. They are defined
 // here so they can be used when processing the config file.
 //
-Object.defineProperty(ao, 'modeMap', {
+Object.defineProperty(apm, 'modeMap', {
   get () {
     return { 0: 0, 1: 1, never: 0, always: 1, disabled: 0, enabled: 1 }
   }
 })
 
-Object.defineProperty(ao, 'modeToStringMap', {
+Object.defineProperty(apm, 'modeToStringMap', {
   get () {
     return { 0: 'disabled', 1: 'enabled' }
   }
@@ -217,10 +217,10 @@ Object.defineProperty(ao, 'modeToStringMap', {
 // Load context provider
 //
 try {
-  ao.cls = require('ace-context')
+  apm.cls = require('ace-context')
 } catch (e) {
   enabled = false
-  log.error('Can\'t load %s', ao.contextProvider, e.stack)
+  log.error('Can\'t load %s', apm.contextProvider, e.stack)
   errors.push('context provider not loaded')
 }
 
@@ -261,7 +261,7 @@ if (!bindings) {
   enabled = false
   bindings = require('./addon-sim')
 }
-ao.addon = bindings
+apm.addon = bindings
 
 //
 // issue a summary error message if the agent is disabled.
@@ -276,14 +276,14 @@ if (!enabled) {
 
 // this is not a class in bindings v6. addon-sim will provide
 // skeleton functions if bindings is not available.
-ao.reporter = bindings.Reporter
+apm.reporter = bindings.Reporter
 
 // set up a debugging logging controller for specific places
-ao.control = { logging: {} }
+apm.control = { logging: {} }
 
 // don't issue errors for what are normal situations at startup.
 let startup = true
-Object.defineProperty(ao, 'startup', {
+Object.defineProperty(apm, 'startup', {
   get () {
     return startup
   },
@@ -296,34 +296,34 @@ Object.defineProperty(ao, 'startup', {
  * Expose debug logging global and create a function to turn
  * logging on/off.
  *
- * @name ao.loggers
+ * @name apm.loggers
  * @property {object} - the loggers available for use
  */
-ao.debugLogging = function (setting) {
+apm.debugLogging = function (setting) {
   log.enabled = setting
 }
 
 // give a quick update
 const x = enabled ? '' : '(disabled)'
 log.debug(
-  `apm ${ao.version}${x}, bindings ${bindings.version}, oboe ${bindings.Config.getVersionString()}`
+  `apm ${apm.version}${x}, bindings ${bindings.version}, oboe ${bindings.Config.getVersionString()}`
 )
 
 //
-// bring in the api or simulated api. it needs access to ao.
+// bring in the api or simulated api. it needs access to apm.
 //
-const api = require(enabled ? './api' : './api-sim')(ao)
+const api = require(enabled ? './api' : './api-sim')(apm)
 
 for (const k of Object.keys(api)) {
-  if (k in ao) {
+  if (k in apm) {
     log.error(`api key ${k} conflicts, skipping`)
   } else {
-    ao[k] = api[k]
+    apm[k] = api[k]
   }
 }
 
-ao.Event.init(ao)
-ao.Span.init(ao)
+apm.Event.init(apm)
+apm.Span.init(apm)
 
 if (config.traceMode === 0) {
   log.debug('tracing disabled by config')
@@ -332,17 +332,17 @@ if (config.traceMode === 0) {
 //
 // now that the api is loaded the trace mode can be set
 //
-ao.traceMode = ao.cfg.traceMode
+apm.traceMode = apm.cfg.traceMode
 
 // and make enabled reflect the final decision
-ao.cfg.enabled = !!enabled
+apm.cfg.enabled = !!enabled
 
 //
 // the rest of the code is only relevant if bindings are loaded.
 //
 if (enabled) {
-  const options = Object.assign({}, ao.cfg)
-  if (ao.execEnv.type !== 'serverless' || ao.execEnv.id !== 'lambda') {
+  const options = Object.assign({}, apm.cfg)
+  if (apm.execEnv.type !== 'serverless' || apm.execEnv.id !== 'lambda') {
     delete options.sampleRate
   }
   options.mode = 1
@@ -357,9 +357,9 @@ if (enabled) {
   const status = bindings.oboeInit(options)
 
   // make sure things are in sync for the lambda environment
-  if (ao.execEnv.id === 'lambda') {
+  if (apm.execEnv.id === 'lambda') {
     if (bindings.Reporter.getType() !== 'lambda') {
-      log.error(`execution environment mismatch ${ao.execEnv.id} vs. ${bindings.Reporter.getType()}`)
+      log.error(`execution environment mismatch ${apm.execEnv.id} vs. ${bindings.Reporter.getType()}`)
     }
     let av = 'n/a'
     try {
@@ -369,29 +369,29 @@ if (enabled) {
 
     let previous
     // if info is not enabled enable it for long enough to output the versions
-    if (!ao.logger.has('info')) {
-      previous = ao.logLevel
-      ao.logLevelAdd('info')
+    if (!apm.logger.has('info')) {
+      previous = apm.logLevel
+      apm.logLevelAdd('info')
     }
     const x = enabled ? '' : '(disabled)'
-    const aov = ao.version
+    const apmv = apm.version
     const abv = bindings.version
     const clv = bindings.Config.getVersionString()
-    ao.loggers.info(`apm ${aov}${x}, bindings ${abv}, oboe ${clv}, auto ${av}`)
+    apm.loggers.info(`apm ${apmv}${x}, bindings ${abv}, oboe ${clv}, auto ${av}`)
     if (previous) {
-      ao.logLevel = previous
+      apm.logLevel = previous
     }
   }
 
-  if (ao.cfg.sampleRate !== undefined) {
-    ao.sampleRate = ao.cfg.sampleRate
+  if (apm.cfg.sampleRate !== undefined) {
+    apm.sampleRate = apm.cfg.sampleRate
   }
 
   if (status > 0) {
     log.error(`failed to initialize, error: ${status}`)
   }
 
-  ao.fs = require('fs')
+  apm.fs = require('fs')
 
   //
   // Collect module data before patching fs
@@ -399,9 +399,9 @@ if (enabled) {
   const base = path.join(process.cwd(), 'node_modules')
   let modules
   try {
-    modules = ao.fs.readdirSync(base)
+    modules = apm.fs.readdirSync(base)
   } catch (e) {}
-  delete ao.fs
+  delete apm.fs
 
   const moduleData = {}
   if (Array.isArray(modules)) {
@@ -421,7 +421,7 @@ if (enabled) {
     // patching registers all probes
     const patcher = require('./require-patch')
     // de-register those probes that have a registered property been specifically set to false
-    Object.keys(ao.probes).filter(prob => ao.probes[prob].registered === false).forEach(probe => patcher.deregister(probe))
+    Object.keys(apm.probes).filter(prob => apm.probes[prob].registered === false).forEach(probe => patcher.deregister(probe))
     patcher.enable()
   }
 
@@ -431,16 +431,16 @@ if (enabled) {
   process.nextTick(function () {
     if (enabled) {
       if (config.runtimeMetrics) {
-        if (ao.execEnv.type !== 'serverless' || ao.execEnv.id !== 'lambda') {
-          ao.loggers.debug('starting runtimeMetrics')
-          ao.metrics = new ao.Metrics()
-          ao.metrics.start()
+        if (apm.execEnv.type !== 'serverless' || apm.execEnv.id !== 'lambda') {
+          apm.loggers.debug('starting runtimeMetrics')
+          apm.metrics = new apm.Metrics()
+          apm.metrics.start()
         } else {
-          ao.loggers.debug('config.runtimeMetrics overridden by lambda environment')
+          apm.loggers.debug('config.runtimeMetrics overridden by lambda environment')
         }
       }
 
-      ao.requestStore.run(function () {
+      apm.requestStore.run(function () {
         const v = process.versions
         const data = {
           __Init: 1,
@@ -453,14 +453,14 @@ if (enabled) {
           'Node.Ares.Version': v.ares,
           'Node.ZLib.Version': v.zlib,
           'Node.HTTPParser.Version': v.llhttp || v.http_parser,
-          'Node.AppOptics.Version': ao.version,
+          'Node.AppOptics.Version': apm.version,
           'Node.AppOpticsExtension.Version': bindings.Config.getVersionString(),
           ...moduleData
         }
 
         log.info('making nodejs:single event')
         const md = bindings.Event.makeRandom(1)
-        const e = new ao.Event('nodejs', 'single', md)
+        const e = new apm.Event('nodejs', 'single', md)
 
         const status = e.sendStatus(data)
         if (status < 0) {
@@ -484,5 +484,5 @@ if (enabled) {
 // cache the exports in our own global so they can be reused
 // if a package like "stealthy-require" clears node's require
 // cache.
-global[aoOnce] = ao
+global[apmOnce] = apm
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // create or get this symbol.
-const apmOnce = Symbol.for('SolarWinds.Apm.Once')
+const apmOnce = Symbol.for('solarwinds-apm')
 
 // remember these before we've required any files so a warning can be issued if needed.
 // filter out this file and the script entry script loaded when the Node.js process launched,

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { loggers: log, addon: aob } = require('.')
+const { loggers: log, addon: apmb } = require('.')
 const v8 = require('v8')
 
 class Metrics {
@@ -16,7 +16,7 @@ class Metrics {
   start () {
     if (this.state !== 'started') {
       // start the metrics gathered by the C++ code
-      aob.metrics.start()
+      apmb.metrics.start()
 
       this.id = setInterval(() => {
         this.reportMetrics()
@@ -31,7 +31,7 @@ class Metrics {
     if (this.state !== 'started') {
       return
     }
-    aob.metrics.stop()
+    apmb.metrics.stop()
     clearInterval(this.id)
     return this.state = 'stopped' // eslint-disable-line no-return-assign
   }
@@ -66,7 +66,7 @@ class Metrics {
   reportMetrics () {
     this.addMetrics()
     this.addMemory()
-    const r = aob.Reporter.sendMetrics(this.metrics)
+    const r = apmb.Reporter.sendMetrics(this.metrics)
     if (r.errors.length > 0) {
       r.errors.forEach(e => {
         if (e.code.startsWith('metric send failed')) {
@@ -81,7 +81,7 @@ class Metrics {
   }
 
   addMetrics () {
-    const metrics = aob.metrics.getMetrics()
+    const metrics = apmb.metrics.getMetrics()
     if (metrics.gc) {
       this.addMetricV('gc.count', metrics.gc.gcCount)
       this.addMetricV('gc.time', metrics.gc.gcTime);

--- a/lib/probes/@hapi/hapi.js
+++ b/lib/probes/@hapi/hapi.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ao = global[Symbol.for('SolarWinds.Apm.Once')]
+const ao = global[Symbol.for('solarwinds-apm')]
 const path = require('path')
 
 const requirePatch = require(path.resolve(ao.root, 'lib', 'require-patch'))

--- a/lib/probes/@hapi/vision.js
+++ b/lib/probes/@hapi/vision.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ao = global[Symbol.for('SolarWinds.Apm.Once')]
+const ao = global[Symbol.for('solarwinds-apm')]
 const path = require('path')
 
 const shimmer = require('shimmer')

--- a/lib/span.js
+++ b/lib/span.js
@@ -4,7 +4,7 @@
 {
 const util = require('util')
 const Event = require('./event')
-let ao
+let apm
 let log
 let dbSendError
 
@@ -33,7 +33,7 @@ const stats = {
  * @param {object} [data] Key/Value pairs of info to add to event
  *
  * @example
- * var span = new Span('fs', ao.lastEvent, {
+ * var span = new Span('fs', apm.lastEvent, {
  *   File: file
  * })
  */
@@ -50,7 +50,7 @@ function Span (name, settings, data) {
     exit: null
   }
 
-  this.returnXtraceHeader = ao.lambda ? !!settings.inboundXtrace : true
+  this.returnXtraceHeader = apm.lambda ? !!settings.inboundXtrace : true
 
   if (!name) {
     throw new TypeError(`invalid span name ${name}`)
@@ -80,8 +80,8 @@ function Span (name, settings, data) {
   this.events.exit = exit
 }
 
-const getSpan = util.deprecate(() => ao.lastSpan, 'use ao.lastSpan instead of Span.last')
-const setSpan = util.deprecate(span => ao.lastSpan = span, 'use ao.lastSpan instead of Span.last') // eslint-disable-line no-return-assign
+const getSpan = util.deprecate(() => apm.lastSpan, 'use apm.lastSpan instead of Span.last')
+const setSpan = util.deprecate(span => apm.lastSpan = span, 'use apm.lastSpan instead of Span.last') // eslint-disable-line no-return-assign
 
 Object.defineProperty(Span, 'last', {
   get: getSpan,
@@ -95,7 +95,7 @@ Object.defineProperty(Span, 'last', {
  *
  * @method Span.makeEntrySpan
  * @param {string} name the name for the span.
- * @param {object} settings the object returned by ao.getTraceSettings()
+ * @param {object} settings the object returned by apm.getTraceSettings()
  * @param {object} kvpairs key/value pairs to be added to the entry event
  */
 Span.makeEntrySpan = function makeEntrySpan (name, settings, kvpairs) {
@@ -104,7 +104,7 @@ Span.makeEntrySpan = function makeEntrySpan (name, settings, kvpairs) {
   log.span('Span.makeEntrySpan %s from inbound %x', name, settings.traceTaskId)
 
   // use the Event from settings or make new (error getting settings or testing).
-  const traceTaskId = settings.traceTaskId || ao.addon.Event.makeRandom(settings.doSample)
+  const traceTaskId = settings.traceTaskId || apm.addon.Event.makeRandom(settings.doSample)
   const { edge, inboundXtrace } = settings
 
   const span = new Span(name, { traceTaskId, edge, inboundXtrace }, kvpairs)
@@ -157,8 +157,8 @@ Span.makeEntrySpan = function makeEntrySpan (name, settings, kvpairs) {
  * })
  */
 Span.prototype.descend = function (name, data) {
-  const last = ao.lastEvent
-  log.span('span.descend %s from ao.lastEvent %e', name, last)
+  const last = apm.lastEvent
+  log.span('span.descend %s from apm.lastEvent %e', name, last)
 
   // if this trace is not sampled then avoid as much work as possible.
   if (!this.doSample) {
@@ -266,15 +266,15 @@ Span.prototype.runPromise = async function (pfunc, options) {
   }
 
   try {
-    ctx = ao.requestStore.createContext({ newContext: this.topSpan })
-    ao.requestStore.enter(ctx)
+    ctx = apm.requestStore.createContext({ newContext: this.topSpan })
+    apm.requestStore.enter(ctx)
   } catch (e) {
     log.error(`${this.name} span failed to enter context ${e.message}`, e.stack)
   }
 
   // Attach backtrace if sampling and enabled.
   if (this.doSample && options.collectBacktraces) {
-    this.events.entry.set({ Backtrace: ao.backtrace() })
+    this.events.entry.set({ Backtrace: apm.backtrace() })
   }
 
   if (this.doMetrics) {
@@ -311,7 +311,7 @@ Span.prototype.runPromise = async function (pfunc, options) {
 
       try {
         if (ctx) {
-          ao.requestStore.exit(ctx)
+          apm.requestStore.exit(ctx)
         }
       } catch (e) {
         log.error(`${this.name} span failed to exit context`, e.stack)
@@ -398,8 +398,8 @@ Span.prototype.runAsync = function (fn) {
   let startTime
 
   try {
-    ctx = ao.requestStore.createContext({ newContext: this.topSpan })
-    ao.requestStore.enter(ctx)
+    ctx = apm.requestStore.createContext({ newContext: this.topSpan })
+    apm.requestStore.enter(ctx)
   } catch (e) {
     log.error(`${this.name} span failed to enter context`, e.stack)
   }
@@ -413,7 +413,7 @@ Span.prototype.runAsync = function (fn) {
   // it, then runs the user's runner function. That way our wrapper is invoked
   // before the user's callback. handler is used only for memcached. No other
   // callback function supplies it.
-  const ret = fn.call(span, (cb, handler) => ao.bind(function (error) {
+  const ret = fn.call(span, (cb, handler) => apm.bind(function (error) {
     if (handler) {
       // handler is present only for some memcached functions.
       // TODO BAM how to handle this with customTxName...
@@ -439,7 +439,7 @@ Span.prototype.runAsync = function (fn) {
 
   try {
     if (ctx) {
-      ao.requestStore.exit(ctx)
+      apm.requestStore.exit(ctx)
     }
   } catch (e) {
     log.error(`${this.name} span failed to exit context`, e.stack)
@@ -558,8 +558,8 @@ Span.prototype.runSync = function (fn) {
       if (this.doMetrics) {
         startTime = Date.now()
       }
-      ctx = ao.requestStore.createContext({ newContext: true })
-      ao.requestStore.enter(ctx)
+      ctx = apm.requestStore.createContext({ newContext: true })
+      apm.requestStore.enter(ctx)
     }
   } catch (e) {
     log.error(`${this.name} span failed to enter context`, e.stack)
@@ -580,7 +580,7 @@ Span.prototype.runSync = function (fn) {
       const txname = this.getTransactionName()
       const et = (Date.now() - startTime) * 1000
 
-      const finaltxname = Span.sendNonHttpSpan(txname, et, error || (ao.lambda && ret instanceof Error))
+      const finaltxname = Span.sendNonHttpSpan(txname, et, error || (apm.lambda && ret instanceof Error))
       kvpairs.TransactionName = finaltxname
       if (txname !== finaltxname) {
         log.warn('Span.runAsync txname error: %s !== %s', txname, finaltxname)
@@ -591,13 +591,13 @@ Span.prototype.runSync = function (fn) {
 
     try {
       if (ctx) {
-        ao.requestStore.exit(ctx)
+        apm.requestStore.exit(ctx)
       }
     } catch (e) {
       log.error(`${this.name} span failed to exit context`, e.stack)
     }
 
-    if (this.topSpan && ao.lambda) {
+    if (this.topSpan && apm.lambda) {
       // TODO BAM topSpans are all async. should this check for .then or
       // just let it return a value? and what about the callback version...
       if (!ret || typeof ret.then !== 'function') {
@@ -641,7 +641,7 @@ Span.prototype.runSync = function (fn) {
  * // manually and bind the callback to maintain the trace context
  * span.async = true
  * span.enter()
- * asyncCallToTrace(ao.bind(function (err, res) {
+ * asyncCallToTrace(apm.bind(function (err, res) {
  *   span.exit()
  *   callback(err, res)
  * }))
@@ -658,21 +658,21 @@ Span.prototype.enter = function (data) {
   }
 
   if (this.topSpan) {
-    ao.requestStore.set('topSpan', this)
+    apm.requestStore.set('topSpan', this)
     stats.topSpansActive += 1
     if (stats.topSpansActive > stats.topSpansMax) {
       stats.topSpansMax = stats.topSpansActive
     }
-    if (ao.lambda) {
-      ao.lambda.invocations += 1
-      data = Object.assign({ InvocationCount: ao.lambda.invocations }, data)
+    if (apm.lambda) {
+      apm.lambda.invocations += 1
+      data = Object.assign({ InvocationCount: apm.lambda.invocations }, data)
     }
   } else {
     stats.otherSpansActive += 1
   }
 
   try {
-    ao.lastSpan = this
+    apm.lastSpan = this
 
     // Send the entry event
     entry.sendReport(data)
@@ -711,7 +711,7 @@ Span.prototype.exit = function (data) {
 
   try {
     // Edge back to previous event, if not already connected
-    const last = ao.lastEvent
+    const last = apm.lastEvent
     if (last && last !== this.events.entry && !exit.ignore) {
       exit.edges.push(last)
     } else if (!last) {
@@ -730,8 +730,8 @@ Span.prototype.exit = function (data) {
 
     // send any pending buffers now so lambda won't timeout before
     // oboe has a chance to send.
-    if (this.topSpan && ao.execEnv.id === 'lambda') {
-      const status = ao.reporter.flush()
+    if (this.topSpan && apm.execEnv.id === 'lambda') {
+      const status = apm.reporter.flush()
       if (status !== 0) {
         log.warn('reporter.flush() status: %i', status)
       }
@@ -784,7 +784,7 @@ Span.prototype.setExitError = function (error) {
  * @param {Object} data Key/Value pairs to add to event
  */
 Span.prototype._internal = function (label, data) {
-  const last = ao.lastEvent
+  const last = apm.lastEvent
   if (!last) {
     log.error(`${this.name} span ${label} call could not find last event`)
     return
@@ -893,12 +893,12 @@ Span.prototype.setIgnoreErrorFn = function setIgnoreErrorFn (fn) {
 Span.sendNonHttpSpan = function (txname, duration, error) {
   const args = {
     txname,
-    // domain: ao.cfg.domainPrefix ? ao.getDomainPrefix(req) : '',
+    // domain: apm.cfg.domainPrefix ? apm.getDomainPrefix(req) : '',
     duration,
     error: !!error
   }
 
-  const finalTxName = ao.reporter.sendNonHttpSpan(args)
+  const finalTxName = apm.reporter.sendNonHttpSpan(args)
 
   // if it's good and not a null string return it.
   if (typeof finalTxName === 'string' && finalTxName) {
@@ -920,8 +920,8 @@ Span.sendNonHttpSpan = function (txname, duration, error) {
 Span.prototype.getTransactionName = function () {
   let txname
 
-  if (ao.cfg.transactionName) {
-    return ao.cfg.transactionName
+  if (apm.cfg.transactionName) {
+    return apm.cfg.transactionName
   }
 
   if (this.customTxName) {
@@ -957,13 +957,13 @@ Span.toError = function (error) {
   }
 }
 
-// because this module is invoked before the ao object is initialized
-// data required from ao must be deferred until init is called.
-Span.init = function (populatedAo) {
-  ao = populatedAo
-  ao._stats.span = stats
-  log = ao.loggers
-  dbSendError = new ao.loggers.Debounce('error')
+// because this module is invoked before the apm object is initialized
+// data required from apm must be deferred until init is called.
+Span.init = function (populatedapm) {
+  apm = populatedapm
+  apm._stats.span = stats
+  log = apm.loggers
+  dbSendError = new apm.loggers.Debounce('error')
 }
 
 module.exports = Span

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "test": "./test.sh",
     "test:core": "./test.sh CORE",
+    "test:probes": "./test.sh PROBES",
     "docs:api": "cat lib/index.js lib/api.js lib/span.js lib/event.js > api-docs-temp.js && jsdoc2md -f api-docs-temp.js > docs/api.md && rm api-docs-temp.js",
     "lint": "eslint . --ext .json,.js,.yml --fix --ignore-pattern bench --ignore-pattern test/docker",
     "dev": "dev/start.sh",

--- a/test/1.test-common.js
+++ b/test/1.test-common.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const ao = require('../lib')
+const apm = require('../lib')
 const util = require('util')
 
 // require should so that individual tests can be debugged using
@@ -12,28 +12,28 @@ const should = require('should') // eslint-disable-line
 const env = process.env
 
 if (env.SW_APM_REPORTER !== 'udp') {
-  ao.loggers.warn('It looks like you need to "source env.sh bash" for tests to work correctly')
+  apm.loggers.warn('It looks like you need to "source env.sh bash" for tests to work correctly')
 }
 
-ao.loggers.addGroup({
+apm.loggers.addGroup({
   groupName: 'test',
   subNames: ['info', 'mock-port', 'messages', 'span', 'cls', 'debug']
 })
 
-if (!ao.g.taskDict) {
-  ao.g.taskDict = {}
+if (!apm.g.taskDict) {
+  apm.g.taskDict = {}
 }
 
 function startTest (file, options = {}) {
-  ao.g.current = file.slice(file.lastIndexOf('/') + 1)
-  ao.loggers.test.info('starting test: ', file)
-  ao.loggers.test.cls(`entering ${ao.g.current}: %c`, ao.requestStore)
+  apm.g.current = file.slice(file.lastIndexOf('/') + 1)
+  apm.loggers.test.info('starting test: ', file)
+  apm.loggers.test.cls(`entering ${apm.g.current}: %c`, apm.requestStore)
 
   applyOptions(options)
 }
 
 function endTest (options = {}) {
-  ao.loggers.test.cls(`exiting ${ao.g.current}: %c`, ao.requestStore)
+  apm.loggers.test.cls(`exiting ${apm.g.current}: %c`, apm.requestStore)
 
   applyOptions(options)
 }
@@ -44,7 +44,7 @@ const debugOptions = {
 
 function applyOptions (options) {
   // work when using standard cls-hooked.
-  if (!ao.requestStore.setDebugOptions) {
+  if (!apm.requestStore.setDebugOptions) {
     return
   }
   // don't modify the caller's options object
@@ -57,7 +57,7 @@ function applyOptions (options) {
 
     opts = Object.assign({}, debugOptions, opts)
   }
-  ao.requestStore.setDebugOptions(opts)
+  apm.requestStore.setDebugOptions(opts)
 }
 
 const formatters = {
@@ -107,10 +107,10 @@ function clsFormatAbbrev (active) {
 }
 
 // make function available without explicit imports
-ao.g.testing = startTest // replace no-op
-ao.g.startTest = startTest
-ao.g.endTest = endTest
+apm.g.testing = startTest // replace no-op
+apm.g.startTest = startTest
+apm.g.endTest = endTest
 
-exports.ao = ao
+exports.apm = apm
 exports.startTest = startTest
 exports.endTest = endTest

--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -4,56 +4,56 @@
 // note: expect() triggers a lint no-unused-expressions. no apparent reason
 /* eslint-disable no-unused-expressions */
 
-const ao = require('..')
-const Span = ao.Span
+const apm = require('..')
+const Span = apm.Span
 const expect = require('chai').expect
 
 const helper = require('./helper')
 const makeSettings = helper.makeSettings
 
-let ifaob // execute or skip test depending on whether bindings are loaded.
+let ifapmb // execute or skip test depending on whether bindings are loaded.
 let MAX_SAMPLE_RATE
 
-if (ao.addon) {
-  ifaob = it
-  MAX_SAMPLE_RATE = ao.addon.MAX_SAMPLE_RATE
+if (apm.addon) {
+  ifapmb = it
+  MAX_SAMPLE_RATE = apm.addon.MAX_SAMPLE_RATE
 } else {
-  ifaob = it.skip
+  ifapmb = it.skip
   MAX_SAMPLE_RATE = 1000000
 }
 
 describe('basics', function () {
   it('should set trace mode as string or integer and always get a string', function () {
-    ao.traceMode = 'never'
-    expect(ao.traceMode).equal('disabled')
+    apm.traceMode = 'never'
+    expect(apm.traceMode).equal('disabled')
 
-    ao.traceMode = 'always'
-    expect(ao.traceMode).equal('enabled')
+    apm.traceMode = 'always'
+    expect(apm.traceMode).equal('enabled')
 
-    ao.traceMode = 0
-    expect(ao.traceMode).equal('disabled')
+    apm.traceMode = 0
+    expect(apm.traceMode).equal('disabled')
 
-    ao.traceMode = 1
-    expect(ao.traceMode).equal('enabled')
+    apm.traceMode = 1
+    expect(apm.traceMode).equal('enabled')
 
-    ao.traceMode = 'disabled'
-    expect(ao.traceMode).equal('disabled')
+    apm.traceMode = 'disabled'
+    expect(apm.traceMode).equal('disabled')
 
-    ao.traceMode = 'enabled'
-    expect(ao.traceMode).equal('enabled')
+    apm.traceMode = 'enabled'
+    expect(apm.traceMode).equal('enabled')
   })
 
-  ifaob('should set and get sample rate', function () {
-    ao.sampleRate = 0
-    expect(ao.sampleRate).equal(0, 'when setting to 0')
-    ao.sampleRate = 1000000
-    expect(ao.sampleRate).equal(1000000, 'when setting to 1000000')
-    ao.sampleRate = 100
-    expect(ao.sampleRate).equal(100, 'when setting to 100')
+  ifapmb('should set and get sample rate', function () {
+    apm.sampleRate = 0
+    expect(apm.sampleRate).equal(0, 'when setting to 0')
+    apm.sampleRate = 1000000
+    expect(apm.sampleRate).equal(1000000, 'when setting to 1000000')
+    apm.sampleRate = 100
+    expect(apm.sampleRate).equal(100, 'when setting to 100')
   })
 
   // TODO: check helper.checkLogMessages and why substitution happens at .github but not locally
-  ifaob.skip('should handle invalid sample rates correctly', function () {
+  ifapmb.skip('should handle invalid sample rates correctly', function () {
     const logChecks = [
       { level: 'warn', message: 'Invalid sample rate: %s, not changed', values: [NaN] },
       { level: 'warn', message: 'Sample rate (%s) out of range, using %s', values: [2000000, 1000000] },
@@ -61,80 +61,80 @@ describe('basics', function () {
     ]
     helper.checkLogMessages(logChecks)
 
-    ao.sampleRate = NaN
-    expect(ao.sampleRate).equal(100, '(unchanged) when trying to set to NaN')
-    ao.sampleRate = 2000000
-    expect(ao.sampleRate).equal(1000000, 'when trying to set to 2000000')
-    ao.sampleRate = -10
-    expect(ao.sampleRate).equal(0, 'when trying to set to a negative number')
-    ao.sampleRate = 100
-    expect(ao.sampleRate).equal(100, 'setting back to the original')
+    apm.sampleRate = NaN
+    expect(apm.sampleRate).equal(100, '(unchanged) when trying to set to NaN')
+    apm.sampleRate = 2000000
+    expect(apm.sampleRate).equal(1000000, 'when trying to set to 2000000')
+    apm.sampleRate = -10
+    expect(apm.sampleRate).equal(0, 'when trying to set to a negative number')
+    apm.sampleRate = 100
+    expect(apm.sampleRate).equal(100, 'setting back to the original')
   })
 
   it('should set sample source', function () {
-    ao.sampleSource = 100
+    apm.sampleSource = 100
   })
 
   it('should get sample source', function () {
-    expect(ao.sampleSource).equal(100)
+    expect(apm.sampleSource).equal(100)
   })
 
-  ifaob('should be able to check an Event\'s sample flag', function () {
-    const md0 = new ao.addon.Event.makeRandom() // eslint-disable-line new-cap
-    const md1 = new ao.addon.Event.makeRandom(1) // eslint-disable-line new-cap
+  ifapmb('should be able to check an Event\'s sample flag', function () {
+    const md0 = new apm.addon.Event.makeRandom() // eslint-disable-line new-cap
+    const md1 = new apm.addon.Event.makeRandom(1) // eslint-disable-line new-cap
 
-    expect(ao.sampling(md0)).equal(false)
-    expect(ao.sampling(md0.toString())).equal(false)
-    expect(ao.sampling(md1)).equal(true)
-    expect(ao.sampling(md1.toString())).equal(true)
+    expect(apm.sampling(md0)).equal(false)
+    expect(apm.sampling(md0.toString())).equal(false)
+    expect(apm.sampling(md1)).equal(true)
+    expect(apm.sampling(md1.toString())).equal(true)
   })
 
-  ifaob('should be able to detect if it is in a trace', function () {
-    expect(ao.tracing).to.be.false
+  ifapmb('should be able to detect if it is in a trace', function () {
+    expect(apm.tracing).to.be.false
     const span = Span.makeEntrySpan('test', makeSettings())
 
     span.run(function () {
-      expect(ao.tracing).equal(true)
+      expect(apm.tracing).equal(true)
     })
   })
 
   it('should support sampling using getTraceSettings()', function () {
-    const skipSample = ao.skipSample
-    ao.skipSample = false
-    ao.traceMode = 'always'
-    ao.sampleRate = MAX_SAMPLE_RATE
-    let s = ao.getTraceSettings()
+    const skipSample = apm.skipSample
+    apm.skipSample = false
+    apm.traceMode = 'always'
+    apm.sampleRate = MAX_SAMPLE_RATE
+    let s = apm.getTraceSettings()
     expect(s).to.not.be.false
 
-    ao.sampleRate = 1
+    apm.sampleRate = 1
     const samples = []
     for (let i = 0; i < 1000; i++) {
-      s = ao.getTraceSettings()
+      s = apm.getTraceSettings()
       samples.push(s.doSample)
     }
     samples.should.containEql(false)
-    ao.skipSample = skipSample
+    apm.skipSample = skipSample
   })
 
-  ifaob('should not call sampleRate setter from sample function', function () {
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    const skipSample = ao.skipSample
-    ao.skipSample = false
+  ifapmb('should not call sampleRate setter from sample function', function () {
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    const skipSample = apm.skipSample
+    apm.skipSample = false
 
     function after (err) {
       expect(err).equal(undefined)
-      ao.addon.Context.setDefaultSampleRate = old
-      ao.skipSample = skipSample
+      apm.addon.Context.setDefaultSampleRate = old
+      apm.skipSample = skipSample
     }
 
-    const old = ao.addon.Context.setDefaultSampleRate
-    ao.addon.Context.setDefaultSampleRate = function () {
+    const old = apm.addon.Context.setDefaultSampleRate
+    apm.addon.Context.setDefaultSampleRate = function () {
       after()
       throw new Error('Should not have called sampleRate setter')
     }
 
-    ao.getTraceSettings()
+    apm.getTraceSettings()
     after()
   })
 
@@ -145,7 +145,7 @@ describe('basics', function () {
     helper.checkLogMessages(logChecks)
     const key = require.resolve('..')
     delete require.cache[key]
-    const ao2 = require('..')
-    expect(ao).equal(ao2)
+    const apm2 = require('..')
+    expect(apm).equal(apm2)
   })
 })

--- a/test/composite/axios.test.js
+++ b/test/composite/axios.test.js
@@ -2,8 +2,8 @@
 'use strict'
 
 const helper = require('../helper')
-const ao = helper.ao
-const addon = ao.addon
+const apm = helper.apm
+const addon = apm.addon
 
 const axios = require('axios')
 const http = require('http')
@@ -19,8 +19,8 @@ describe('composite.axios', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
   })
   after(function (done) {
     emitter.close(done)
@@ -76,13 +76,13 @@ describe('composite.axios', function () {
   // server
   //
   describe('http-server', function () {
-    const conf = ao.probes.http
+    const conf = apm.probes.http
 
     // it's possible for a local UDP send to fail but oboe doesn't report
     // it, so compensate for it.
     it('UDP might lose a message running locally', function (done) {
       helper.test(emitter, function (done) {
-        ao.instrument('fake', function () { })
+        apm.instrument('fake', function () { })
         done()
       }, [
         function (msg) {
@@ -133,7 +133,7 @@ describe('composite.axios', function () {
         res.end('done')
       })
 
-      const origin = new ao.Event('span-name', 'label-name', addon.Event.makeRandom(1))
+      const origin = new apm.Event('span-name', 'label-name', addon.Event.makeRandom(1))
 
       helper.doChecks(emitter, [
         function (msg) {
@@ -168,7 +168,7 @@ describe('composite.axios', function () {
         res.end('done')
       })
 
-      const origin = new ao.Event('span-name', 'label-name', addon.Event.makeRandom(1))
+      const origin = new apm.Event('span-name', 'label-name', addon.Event.makeRandom(1))
       const traceparent = origin.toString().slice(0, 42) + '0'.repeat(16) + '01'
 
       const logChecks = [
@@ -269,7 +269,7 @@ describe('composite.axios', function () {
     // Verify query param filtering support
     //
     it('should support query param filtering', function (done) {
-      ao.probes['http-client'].enabled = false
+      apm.probes['http-client'].enabled = false
       conf.includeRemoteUrlParams = false
       const server = http.createServer(function (req, res) {
         res.end('done')
@@ -285,7 +285,7 @@ describe('composite.axios', function () {
         }
       ], function (err) {
         conf.includeRemoteUrlParams = true
-        ao.probes['http-client'].enabled = true
+        apm.probes['http-client'].enabled = true
         server.close(done.bind(null, err))
       })
 
@@ -466,7 +466,7 @@ describe('composite.axios', function () {
   // client
   //
   describe('http-client', function () {
-    const conf = ao.probes['http-client']
+    const conf = apm.probes['http-client']
 
     it('should trace http.get', function (done) {
       const server = http.createServer(function (req, res) {
@@ -503,13 +503,13 @@ describe('composite.axios', function () {
         axios.get('http://www.google.com')
           .then(response => {
             if (response.status !== 200) {
-              ao.loggers.error('status', response.status)
+              apm.loggers.error('status', response.status)
             }
             res.end('done')
             server.close()
           })
           .catch(err => {
-            ao.loggers.error('error', err)
+            apm.loggers.error('error', err)
             res.statusCode = 422
             res.end({ geterror: err.toString() })
             server.close()
@@ -565,13 +565,13 @@ describe('composite.axios', function () {
         axios.get(url2)
           .then(response => {
             if (response.status !== 200) {
-              ao.loggers.error('status', response.status)
+              apm.loggers.error('status', response.status)
             }
             res.end('done')
             server.close()
           })
           .catch(err => {
-            ao.loggers.error('error', err)
+            apm.loggers.error('error', err)
             res.statusCode = 422
             res.end({ geterror: err.toString() })
             server.close()
@@ -640,13 +640,13 @@ describe('composite.axios', function () {
         axios(options)
           .then(function (response) {
             if (response.status !== 200) {
-              ao.loggers.error('status', response.status)
+              apm.loggers.error('status', response.status)
             }
             res.end('done')
             server.close()
           })
           .catch(function (err) {
-            ao.loggers.error('error', err)
+            apm.loggers.error('error', err)
             res.statusCode = 422
             res.end({ geterror: err.toString() })
             server.close()

--- a/test/connect.test.js
+++ b/test/connect.test.js
@@ -3,13 +3,13 @@
 
 process.env.APPOPTICS_REPORTER = 'ssl'
 
-const ao = require('..')
+const apm = require('..')
 const assert = require('assert')
 
 describe('verify that agent can connect to collector', function () {
   it('should connect to the collector using the token', function () {
     const o = {}
-    const ready = ao.readyToSample(5000, o)
+    const ready = apm.readyToSample(5000, o)
     assert.strictEqual(o.status, 1, `expected status 1, not ${o.status}`)
     // return value should be true
     assert.strictEqual(ready, true, 'should return boolean true')

--- a/test/context-no-mocha.test.js
+++ b/test/context-no-mocha.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const expect = require('chai').expect
-const ao = require('..')
+const apm = require('..')
 
 const gc = global.gc || (() => true)
 
@@ -22,7 +22,7 @@ async function t1 (main) {
 
   let p
   // promiseStartOrContinueTrace. psoon's ...args are used to resolve the promise.
-  const res = ao.pStartOrContinueTrace(
+  const res = apm.pStartOrContinueTrace(
     null,
     main, // span name
     // promise-returning runner
@@ -66,17 +66,17 @@ let doneFlag = false
 
 async function noop () {
   if (noopsCollect) gc()
-  return ['noop', `test-${ix}`, [...ao.requestStore._contexts.keys()]]
+  return ['noop', `test-${ix}`, [...apm.requestStore._contexts.keys()]]
 }
 async function done () {
   doneFlag = true
-  return ['set doneFlag', `test-${ix}`, [...ao.requestStore._contexts.keys()]]
+  return ['set doneFlag', `test-${ix}`, [...apm.requestStore._contexts.keys()]]
 }
 
-output('start', [...ao.requestStore._contexts.keys()])
+output('start', [...apm.requestStore._contexts.keys()])
 
 const i0 = setInterval(function () {
-  output('separate', ao.lastEvent)
+  output('separate', apm.lastEvent)
   if (doneFlag) clearInterval(i0)
 }, 1000)
 
@@ -88,7 +88,7 @@ const interval = setInterval(function () {
         ix += 1
       })
   } else {
-    output('clearing interval 1', [...ao.requestStore._contexts.keys()])
+    output('clearing interval 1', [...apm.requestStore._contexts.keys()])
     clearInterval(interval)
   }
 }, 1000)
@@ -102,9 +102,9 @@ const i2 = setInterval(function () {
   if (++counter > 3) {
     output('clearing interval 2')
     clearInterval(i2)
-    expect(ao.lastEvent).equal(undefined)
-    expect([...ao.requestStore._contexts.keys()]).property('length', 0)
+    expect(apm.lastEvent).equal(undefined)
+    expect([...apm.requestStore._contexts.keys()]).property('length', 0)
   }
-  output('countdown', ao.lastEvent, [...ao.requestStore._contexts.keys()])
+  output('countdown', apm.lastEvent, [...apm.requestStore._contexts.keys()])
   gc()
 }, 3000)

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -492,10 +492,10 @@ describe('custom', function () {
       let count = 0
 
       const logChecks = [
-        { level: 'error', message: 'ao.instrument() run function is' },
-        { level: 'error', message: 'ao.runInstrument found no span name or span-info()' },
-        { level: 'error', message: 'ao.runInstrument failed to build span' },
-        { level: 'error', message: 'ao.runInstrument failed to build span' },
+        { level: 'error', message: 'apm.instrument() run function is' },
+        { level: 'error', message: 'apm.runInstrument found no span name or span-info()' },
+        { level: 'error', message: 'apm.runInstrument failed to build span' },
+        { level: 'error', message: 'apm.runInstrument failed to build span' },
         { level: 'error', message: 'no name supplied to runInstrument by span-info()' }
       ]
       helper.checkLogMessages(logChecks)
@@ -547,13 +547,13 @@ describe('custom', function () {
       const psoct = 'pStartOrContinueTrace'
       const logChecks = [
         // verify nothing bad happens when run function is missing
-        { level: 'error', message: 'ao.instrument() run function is' },
+        { level: 'error', message: 'apm.instrument() run function is' },
         { level: 'error', message: `${psoct} requires a function, not ${typeof missing}` },
         // verify nothing bad happens when spanInfo() is missing
-        { level: 'error', message: 'ao.runInstrument found no span name or span-info()' },
+        { level: 'error', message: 'apm.runInstrument found no span name or span-info()' },
         { level: 'error', message: `${psoct} span argument must be a string or function, not ${typeof protoSpan}` },
         // verify the runner is still run when spanInfo fails to return a correct object
-        { level: 'error', message: 'ao.runInstrument failed to build span' },
+        { level: 'error', message: 'apm.runInstrument failed to build span' },
         { level: 'error', message: `${psoct} span-info bad values: name` },
         // verify the runner is still run when spanInfo() fails to return a name
         { level: 'error', message: 'no name supplied to runInstrument by span-info()' },
@@ -604,8 +604,8 @@ describe('custom', function () {
       let count = 0
 
       const logChecks = [
-        { level: 'error', message: 'ao.runInstrument failed to build span' },
-        { level: 'error', message: 'ao.runInstrument failed to build span' }
+        { level: 'error', message: 'apm.runInstrument failed to build span' },
+        { level: 'error', message: 'apm.runInstrument failed to build span' }
       ]
       helper.checkLogMessages(logChecks)
 

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -2,9 +2,9 @@
 'use strict'
 
 const helper = require('./helper')
-const ao = require('..')
-const Span = ao.Span
-const Event = ao.Event
+const apm = require('..')
+const Span = apm.Span
+const Event = apm.Event
 const should = require('should') // eslint-disable-line no-unused-vars
 
 const makeSettings = helper.makeSettings
@@ -39,8 +39,8 @@ describe('error', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
   })
   after(function (done) {
     emitter.close(done)
@@ -56,7 +56,7 @@ describe('error', function () {
   //
   it('might lose a message (until the UDP problem is fixed)', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {
@@ -70,7 +70,7 @@ describe('error', function () {
   // Tests
   //
   it('should add error properties to event', function () {
-    const md = ao.addon.Event.makeRandom(1)
+    const md = apm.addon.Event.makeRandom(1)
     const event = new Event('error-test', 'info', md)
     const err = new Error('test')
     event.error = err
@@ -81,7 +81,7 @@ describe('error', function () {
   })
 
   it('should set error multiple times (keeping last)', function () {
-    const md = ao.addon.Event.makeRandom(1)
+    const md = apm.addon.Event.makeRandom(1)
     const event = new Event('error-test', 'info', md)
     const first = new Error('first')
     const second = new Error('second')
@@ -96,7 +96,7 @@ describe('error', function () {
   it('should report errors in sync calls', function (done) {
     handleErrorTest(function (done) {
       try {
-        ao.instrument(testSpan, function () {
+        apm.instrument(testSpan, function () {
           throw error
         }, conf)
       } catch (e) {}
@@ -107,7 +107,7 @@ describe('error', function () {
   it('should report errors in async calls', function (complete) {
     handleErrorTest(function (done) {
       try {
-        ao.instrument(
+        apm.instrument(
           testSpan,
           function (cb) {
             setTimeout(function () {
@@ -120,7 +120,7 @@ describe('error', function () {
           }
         )
       } catch (e) {
-        ao.loggers.debug('Got error instrumenting', e)
+        apm.loggers.debug('Got error instrumenting', e)
         complete(e)
       }
     }, complete)
@@ -130,7 +130,7 @@ describe('error', function () {
     class CustomError extends Error {}
     const error = new CustomError('test')
     helper.test(emitter, function (done) {
-      ao.instrument(
+      apm.instrument(
         testSpan,
         function (cb) {
           setTimeout(function () {
@@ -159,7 +159,7 @@ describe('error', function () {
 
   it('should report errors in error-first callbacks', function (done) {
     handleErrorTest(function (done) {
-      ao.instrument(
+      apm.instrument(
         testSpan,
         function (callback) {
           callback(error)
@@ -176,7 +176,7 @@ describe('error', function () {
     class CustomError extends Error {}
     const error = new CustomError('test')
     helper.test(emitter, function (done) {
-      ao.reportError(error)
+      apm.reportError(error)
       done()
     }, [
       function (msg) {
@@ -194,8 +194,8 @@ describe('error', function () {
     let last
 
     helper.test(emitter, function (done) {
-      ao.instrument(testSpan, function (callback) {
-        ao.reportError(error)
+      apm.instrument(testSpan, function (callback) {
+        apm.reportError(error)
         callback()
       }, conf, done)
     }, [
@@ -225,7 +225,7 @@ describe('error', function () {
     handleErrorTest(function (done) {
       let rethrow = false
       try {
-        ao.instrument(testSpan, function () {
+        apm.instrument(testSpan, function () {
           throw error
         }, conf)
       } catch (e) {
@@ -241,7 +241,7 @@ describe('error', function () {
   it('should support string errors', function (done) {
     const error = 'test'
     helper.httpTest(emitter, function (done) {
-      ao.reportError(error)
+      apm.reportError(error)
       done()
     }, [
       function (msg) {
@@ -257,7 +257,7 @@ describe('error', function () {
   it('should support empty string errors', function (done) {
     const error = ''
     helper.httpTest(emitter, function (done) {
-      ao.reportError(error)
+      apm.reportError(error)
       done()
     }, [
       function (msg) {
@@ -298,8 +298,8 @@ describe('error', function () {
     }
 
     helper.httpTest(emitter, function (done) {
-      ao.reportError(error)
-      ao.reportError(error)
+      apm.reportError(error)
+      apm.reportError(error)
       done()
     }, [validate, validate], done)
   })

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -2,9 +2,9 @@
 'use strict'
 
 const helper = require('./helper')
-const ao = helper.ao
-const aob = ao.addon
-const Event = ao.Event
+const apm = helper.apm
+const apmb = apm.addon
+const Event = apm.Event
 
 const expect = require('chai').expect
 
@@ -21,15 +21,15 @@ describe('event', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = aob.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apmb.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
   })
   after(function (done) {
     emitter.close(done)
   })
 
   beforeEach(function () {
-    ev0 = aob.Event.makeRandom(1)
+    ev0 = apmb.Event.makeRandom(1)
     const mds = ev0.toString().split('-')
     mdTaskId = mds[1]
     mdOpId = mds[2]
@@ -37,13 +37,13 @@ describe('event', function () {
 
   afterEach(function () {
     if (this.currentTest.title === 'UDP might lose a message') {
-      baseStats = Object.assign({}, ao._stats.event)
+      baseStats = Object.assign({}, apm._stats.event)
     }
   })
 
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () {})
+      apm.instrument('fake', function () {})
       done()
     }, [
       function (msg) {
@@ -74,20 +74,20 @@ describe('event', function () {
 
   // net 4
   it('should fetch an event\'s sample flag', function () {
-    ao.sampleRate = 0
-    ao.traceMode = 'never'
-    ev0 = aob.Event.makeRandom(0)
+    apm.sampleRate = 0
+    apm.traceMode = 'never'
+    ev0 = apmb.Event.makeRandom(0)
     event = new Event('test', 'entry', ev0)
-    expect(ao.sampling(event)).equal(false)
-    expect(ao.sampling(event.toString())).equal(false)
+    expect(apm.sampling(event)).equal(false)
+    expect(apm.sampling(event.toString())).equal(false)
 
-    ao.sampleRate = aob.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ev0 = aob.Event.makeRandom(1)
+    apm.sampleRate = apmb.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    ev0 = apmb.Event.makeRandom(1)
     event = new Event('test', 'entry', ev0)
 
-    expect(ao.sampling(event)).equal(true)
-    expect(ao.sampling(event.toString())).equal(true)
+    expect(apm.sampling(event)).equal(true)
+    expect(apm.sampling(event.toString())).equal(true)
   })
 
   // net 4, sent 1
@@ -105,7 +105,7 @@ describe('event', function () {
     })
 
     // NOTE: events must be sent within a request store context
-    ao.requestStore.run(function () {
+    apm.requestStore.run(function () {
       event2.sendReport()
     })
   })
@@ -141,14 +141,14 @@ describe('event', function () {
       expect(msg).property('Foo', 'fubar')
       done()
     })
-    ao.requestStore.run(function () {
+    apm.requestStore.run(function () {
       event.sendReport({ Foo: 'fubar' })
     })
   })
 
   it('should generate the expected stats', function () {
     // this suite creates 8 events and sends 2 after the UDP test
-    const stats = ao._stats.event
+    const stats = apm._stats.event
     expect(stats.created).equal(baseStats.created + 8, 'events created')
     expect(stats.active).equal(baseStats.active + 6, 'events active')
   })

--- a/test/get-unified-config.test.js
+++ b/test/get-unified-config.test.js
@@ -8,7 +8,6 @@ const expect = require('chai').expect
 const relativeDir = '..'
 const guc = require(`${relativeDir}/lib/get-unified-config`)
 
-console.log(guc)
 //
 // expected results when neither a config file nor environment variables are present.
 //

--- a/test/integrity.test.js
+++ b/test/integrity.test.js
@@ -21,7 +21,7 @@ describe('integrity', function () {
     // all functions operate in a compatible way. that can be added over time if errors
     // turn out to be a problem.
     //
-    const skeletalAo = {
+    const skeletalApm = {
       loggers: {
         addGroup () {},
         Debounce: function () {
@@ -39,11 +39,11 @@ describe('integrity', function () {
     // can't require ../lib/api due to cyclic dependencies.
     // load all and filter out keys that are not api.
     // TODO: when cyclic is solved can revert to pattern as used for api-sim
-    const aoApi = require('../lib/')
+    const apmApi = require('../lib/')
     const notApi = '_stats, version, g, root, omitTraceId, logger, loggers, logLevel, logLevelAdd, logLevelRemove, probes, specialUrls, execEnv, cfg, getDomainPrefix, makeLogMissing, modeMap, modeToStringMap, cls, addon, reporter, control, startup, debugLogging, traceMode, sampleRate, tracing, traceId, lastEvent, lastSpan, maps, requestStore, resetRequestStore, clsCheck, stack, backtrace, bind, bindEmitter, setCustomTxNameFunction, wrappedFlag, fs'
-    const apiKeys = new Set([...new Set([...Object.getOwnPropertyNames(aoApi)])].filter(item => notApi.indexOf(item) === -1))
+    const apiKeys = new Set([...new Set([...Object.getOwnPropertyNames(apmApi)])].filter(item => notApi.indexOf(item) === -1))
 
-    const aoSim = require('../lib/api-sim')(Object.assign({}, skeletalAo))
+    const aoSim = require('../lib/api-sim')(Object.assign({}, skeletalApm))
     const simKeys = new Set([...Object.getOwnPropertyNames(aoSim)])
 
     const missing = new Set()

--- a/test/lambda/local-tests.js
+++ b/test/lambda/local-tests.js
@@ -87,7 +87,7 @@ function fakeLambdaCallbacker (event, context, callback) {
 // requested function.
 //
 
-const aos = Symbol.for('SolarWinds.Apm.Once')
+const aos = Symbol.for('solarwinds-apm')
 
 module.exports = {
   // look in the context data for this symbol for additional instructions.

--- a/test/linger/dummy.test.js
+++ b/test/linger/dummy.test.js
@@ -7,10 +7,10 @@ const { startTest, endTest } = require('../1.test-common.js')
 describe('probes/dummy vz.z.z', function () {
   before(function () {
     startTest(__filename, { customFormatter: 'terse' })
-    // ao.requestStore.dumpCtx()
+    // apm.requestStore.dumpCtx()
   })
   after(function () {
-    // ao.requestStore.dumpCtx()
+    // apm.requestStore.dumpCtx()
     endTest()
   })
   beforeEach(function () {

--- a/test/no-addon/custom.test.js
+++ b/test/no-addon/custom.test.js
@@ -96,7 +96,7 @@ describe('custom (without native bindings present)', function () {
     const store = ao.requestStore
 
     assert(typeof store === 'object')
-    assert(store.name === 'ao-cls-context')
+    assert(store.name === 'apm-cls-context')
     assert(store.constructor.name === 'Namespace')
   })
 

--- a/test/no-addon/custom.test.js
+++ b/test/no-addon/custom.test.js
@@ -3,8 +3,8 @@
 
 process.env.SW_APM_TEST_NO_BINDINGS = '1'
 
-const ao = require('../..')
-const aob = ao.addon
+const apm = require('../..')
+const apmb = apm.addon
 const assert = require('assert')
 
 const soon = global.setImmediate || process.nextTick
@@ -22,12 +22,12 @@ const traceparent = '00-0123456789abcdef0123456789abcdef-7a71b110e5e3588d-01'
 // the custom instrumentation should be a no-op
 describe('custom (without native bindings present)', function () {
   it('should have a bindings version of \'not loaded\'', function () {
-    assert(ao.addon.version === 'not loaded')
+    assert(apm.addon.version === 'not loaded')
   })
 
   it('should passthrough instrumentHttp', function () {
     let counter = 0
-    ao.instrumentHttp('span-name', function () {
+    apm.instrumentHttp('span-name', function () {
       counter += 1
     })
     assert(counter === 1)
@@ -35,7 +35,7 @@ describe('custom (without native bindings present)', function () {
 
   it('should passthrough sync instrument', function () {
     let counter = 0
-    ao.instrument('test', function () {
+    apm.instrument('test', function () {
       counter++
     })
     assert(counter === 1, 'counter should be 1')
@@ -45,7 +45,7 @@ describe('custom (without native bindings present)', function () {
     function localDone () {
       done()
     }
-    ao.instrument('test', soon, {}, localDone)
+    apm.instrument('test', soon, {}, localDone)
   })
 
   it('should passthrough pInstrument', function () {
@@ -56,7 +56,7 @@ describe('custom (without native bindings present)', function () {
       return Promise.resolve(99)
     }
 
-    return ao.pInstrument('test', pfunc).then(r => {
+    return apm.pInstrument('test', pfunc).then(r => {
       assert(counter === 1, 'counter should be 1')
       assert(r === 99, 'the result of pInstrument should be 99')
       return r
@@ -65,7 +65,7 @@ describe('custom (without native bindings present)', function () {
 
   it('should passthrough sync startOrContinueTrace', function () {
     let counter = 0
-    ao.startOrContinueTrace(null, null, 'test', function () {
+    apm.startOrContinueTrace(null, null, 'test', function () {
       counter++
     })
     assert(counter === 1, 'counter should be equal to 1')
@@ -75,7 +75,7 @@ describe('custom (without native bindings present)', function () {
     function localDone () {
       done()
     }
-    ao.startOrContinueTrace(null, null, 'test', soon, localDone)
+    apm.startOrContinueTrace(null, null, 'test', soon, localDone)
   })
 
   it('should passthrough pStartOrContinueTrace', function () {
@@ -85,7 +85,7 @@ describe('custom (without native bindings present)', function () {
       counter += 1
       return Promise.resolve(99)
     }
-    return ao.pStartOrContinueTrace(null, null, 'test', pfunc).then(r => {
+    return apm.pStartOrContinueTrace(null, null, 'test', pfunc).then(r => {
       assert(counter === 1, 'counter should be 1')
       assert(r === 99, 'the result of pStartOrContinueTrace should be 99')
       return r
@@ -93,7 +93,7 @@ describe('custom (without native bindings present)', function () {
   })
 
   it('should passthrough requestStore', function () {
-    const store = ao.requestStore
+    const store = apm.requestStore
 
     assert(typeof store === 'object')
     assert(store.name === 'apm-cls-context')
@@ -101,40 +101,40 @@ describe('custom (without native bindings present)', function () {
   })
 
   it('should support callback shifting', function (done) {
-    ao.instrument('test', soon, done)
+    apm.instrument('test', soon, done)
   })
 
   it('should supply API functions and properties', function () {
-    assert(ao.traceMode === 'disabled')
-    assert(ao.sampleRate === 0)
-    assert(ao.tracing === false)
-    assert(ao.traceId === undefined)
-    assert(ao.lastEvent === undefined)
-    assert(ao.lastSpan === undefined)
-    assert(ao.requestStore && typeof ao.requestStore.get === 'function')
-    assert(typeof ao.resetRequestStore === 'function')
-    assert(ao.clsCheck() === false)
-    assert(ao.stack() === '')
-    assert(ao.bind('x') === 'x')
-    assert(ao.bindEmitter('x') === 'x')
-    assert(ao.backtrace())
-    assert(ao.setCustomTxNameFunction('x') === false)
+    assert(apm.traceMode === 'disabled')
+    assert(apm.sampleRate === 0)
+    assert(apm.tracing === false)
+    assert(apm.traceId === undefined)
+    assert(apm.lastEvent === undefined)
+    assert(apm.lastSpan === undefined)
+    assert(apm.requestStore && typeof apm.requestStore.get === 'function')
+    assert(typeof apm.resetRequestStore === 'function')
+    assert(apm.clsCheck() === false)
+    assert(apm.stack() === '')
+    assert(apm.bind('x') === 'x')
+    assert(apm.bindEmitter('x') === 'x')
+    assert(apm.backtrace())
+    assert(apm.setCustomTxNameFunction('x') === false)
 
-    assert(ao.readyToSample() === false)
-    assert(ao.getTraceSettings().doSample === false)
-    assert(ao.sampling() === false)
-    assert(ao.traceToEvent('') === undefined)
-    assert(ao.traceToEvent(traceparent) instanceof aob.Event)
-    assert(ao.patchResponse('x') === undefined)
-    assert(ao.addResponseFinalizer('x') === undefined)
-    assert(ao.traceId === undefined)
-    assert(ao.reportError(new Error('xyzzy')) === undefined)
-    assert(ao.reportInfo('this is info') === undefined)
+    assert(apm.readyToSample() === false)
+    assert(apm.getTraceSettings().doSample === false)
+    assert(apm.sampling() === false)
+    assert(apm.traceToEvent('') === undefined)
+    assert(apm.traceToEvent(traceparent) instanceof apmb.Event)
+    assert(apm.patchResponse('x') === undefined)
+    assert(apm.addResponseFinalizer('x') === undefined)
+    assert(apm.traceId === undefined)
+    assert(apm.reportError(new Error('xyzzy')) === undefined)
+    assert(apm.reportInfo('this is info') === undefined)
 
-    const o = ao.getTraceObjectForLog()
+    const o = apm.getTraceObjectForLog()
     assert(typeof o === 'object')
     assert(Object.keys(o).length === 0)
 
-    assert(ao.getTraceStringForLog() === '')
+    assert(apm.getTraceStringForLog() === '')
   })
 })

--- a/test/no-service-key/custom.test.js
+++ b/test/no-service-key/custom.test.js
@@ -3,8 +3,8 @@
 
 process.env.SW_APM_SERVICE_KEY = ''
 
-const ao = require('../..')
-const aob = ao.addon
+const apm = require('../..')
+const apmb = apm.addon
 const assert = require('assert')
 
 const soon = global.setImmediate || process.nextTick
@@ -22,12 +22,12 @@ const traceparent = '00-0123456789abcdef0123456789abcdef-7a71b110e5e3588d-01'
 // the custom instrumentation should be a no-op
 describe('custom (without service key present)', function () {
   it('should have a bindings version of \'not loaded\'', function () {
-    assert(ao.addon.version === 'not loaded')
+    assert(apm.addon.version === 'not loaded')
   })
 
   it('should passthrough instrumentHttp', function () {
     let counter = 0
-    ao.instrumentHttp('span-name', function () {
+    apm.instrumentHttp('span-name', function () {
       counter += 1
     })
     assert(counter === 1)
@@ -35,7 +35,7 @@ describe('custom (without service key present)', function () {
 
   it('should passthrough sync instrument', function () {
     let counter = 0
-    ao.instrument('test', function () {
+    apm.instrument('test', function () {
       counter++
     })
     assert(counter === 1, 'counter should be 1')
@@ -45,7 +45,7 @@ describe('custom (without service key present)', function () {
     function localDone () {
       done()
     }
-    ao.instrument('test', soon, {}, localDone)
+    apm.instrument('test', soon, {}, localDone)
   })
 
   it('should passthrough pInstrument', function () {
@@ -56,7 +56,7 @@ describe('custom (without service key present)', function () {
       return Promise.resolve(99)
     }
 
-    return ao.pInstrument('test', pfunc).then(r => {
+    return apm.pInstrument('test', pfunc).then(r => {
       assert(counter === 1, 'counter should be 1')
       assert(r === 99, 'the result of pInstrument should be 99')
       return r
@@ -65,7 +65,7 @@ describe('custom (without service key present)', function () {
 
   it('should passthrough sync startOrContinueTrace', function () {
     let counter = 0
-    ao.startOrContinueTrace(null, null, 'test', function () {
+    apm.startOrContinueTrace(null, null, 'test', function () {
       counter++
     })
     assert(counter === 1, 'counter should be equal to 1')
@@ -75,7 +75,7 @@ describe('custom (without service key present)', function () {
     function localDone () {
       done()
     }
-    ao.startOrContinueTrace(null, null, 'test', soon, localDone)
+    apm.startOrContinueTrace(null, null, 'test', soon, localDone)
   })
 
   it('should passthrough pStartOrContinueTrace', function () {
@@ -85,7 +85,7 @@ describe('custom (without service key present)', function () {
       counter += 1
       return Promise.resolve(99)
     }
-    return ao.pStartOrContinueTrace(null, null, 'test', pfunc).then(r => {
+    return apm.pStartOrContinueTrace(null, null, 'test', pfunc).then(r => {
       assert(counter === 1, 'counter should be 1')
       assert(r === 99, 'the result of pStartOrContinueTrace should be 99')
       return r
@@ -93,7 +93,7 @@ describe('custom (without service key present)', function () {
   })
 
   it('should passthrough requestStore', function () {
-    const store = ao.requestStore
+    const store = apm.requestStore
 
     assert(typeof store === 'object')
     assert(store.name === 'apm-cls-context')
@@ -101,40 +101,40 @@ describe('custom (without service key present)', function () {
   })
 
   it('should support callback shifting', function (done) {
-    ao.instrument('test', soon, done)
+    apm.instrument('test', soon, done)
   })
 
   it('should supply API functions and properties', function () {
-    assert(ao.traceMode === 'disabled')
-    assert(ao.sampleRate === 0)
-    assert(ao.tracing === false)
-    assert(ao.traceId === undefined)
-    assert(ao.lastEvent === undefined)
-    assert(ao.lastSpan === undefined)
-    assert(ao.requestStore && typeof ao.requestStore.get === 'function')
-    assert(typeof ao.resetRequestStore === 'function')
-    assert(ao.clsCheck() === false)
-    assert(ao.stack() === '')
-    assert(ao.bind('x') === 'x')
-    assert(ao.bindEmitter('x') === 'x')
-    assert(ao.backtrace())
-    assert(ao.setCustomTxNameFunction('x') === false)
+    assert(apm.traceMode === 'disabled')
+    assert(apm.sampleRate === 0)
+    assert(apm.tracing === false)
+    assert(apm.traceId === undefined)
+    assert(apm.lastEvent === undefined)
+    assert(apm.lastSpan === undefined)
+    assert(apm.requestStore && typeof apm.requestStore.get === 'function')
+    assert(typeof apm.resetRequestStore === 'function')
+    assert(apm.clsCheck() === false)
+    assert(apm.stack() === '')
+    assert(apm.bind('x') === 'x')
+    assert(apm.bindEmitter('x') === 'x')
+    assert(apm.backtrace())
+    assert(apm.setCustomTxNameFunction('x') === false)
 
-    assert(ao.readyToSample() === false)
-    assert(ao.getTraceSettings().doSample === false)
-    assert(ao.sampling() === false)
-    assert(ao.traceToEvent('') === undefined)
-    assert(ao.traceToEvent(traceparent) instanceof aob.Event)
-    assert(ao.patchResponse('x') === undefined)
-    assert(ao.addResponseFinalizer('x') === undefined)
-    assert(ao.traceId === undefined)
-    assert(ao.reportError(new Error('xyzzy')) === undefined)
-    assert(ao.reportInfo('this is info') === undefined)
+    assert(apm.readyToSample() === false)
+    assert(apm.getTraceSettings().doSample === false)
+    assert(apm.sampling() === false)
+    assert(apm.traceToEvent('') === undefined)
+    assert(apm.traceToEvent(traceparent) instanceof apmb.Event)
+    assert(apm.patchResponse('x') === undefined)
+    assert(apm.addResponseFinalizer('x') === undefined)
+    assert(apm.traceId === undefined)
+    assert(apm.reportError(new Error('xyzzy')) === undefined)
+    assert(apm.reportInfo('this is info') === undefined)
 
-    const o = ao.getTraceObjectForLog()
+    const o = apm.getTraceObjectForLog()
     assert(typeof o === 'object')
     assert(Object.keys(o).length === 0)
 
-    assert(ao.getTraceStringForLog() === '')
+    assert(apm.getTraceStringForLog() === '')
   })
 })

--- a/test/no-service-key/custom.test.js
+++ b/test/no-service-key/custom.test.js
@@ -96,7 +96,7 @@ describe('custom (without service key present)', function () {
     const store = ao.requestStore
 
     assert(typeof store === 'object')
-    assert(store.name === 'ao-cls-context')
+    assert(store.name === 'apm-cls-context')
     assert(store.constructor.name === 'Namespace')
   })
 

--- a/test/probes/@hapi/hapi.test.js
+++ b/test/probes/@hapi/hapi.test.js
@@ -7,7 +7,7 @@ const path = require('path')
 const helloDotEjs = 'hello.ejs'
 
 const helper = require(path.join(base, 'test/helper'))
-const ao = global[Symbol.for('SolarWinds.Apm.Once')]
+const apm = global[Symbol.for('SolarWinds.Apm.Once')]
 
 const axios = require('axios')
 
@@ -32,14 +32,14 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.probes.fs.enabled = false
+    apm.probes.fs.enabled = false
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(done)
   })
   afterEach(function () {
@@ -232,7 +232,7 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
   }
 
   async function disabledTest () {
-    ao.probes['@hapi/vision'].enabled = false
+    apm.probes['@hapi/vision'].enabled = false
     const server = await makeViewServer()
 
     server.route({
@@ -254,7 +254,7 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
     const validations = [checks.httpEntry, checks.hapiEntry, checks.hapiExit, checks.httpExit]
 
     helper.doChecks(emitter, validations, function () {
-      ao.probes['@hapi/vision'].enabled = true
+      apm.probes['@hapi/vision'].enabled = true
       server.listener.close(_resolve)
     })
 
@@ -269,7 +269,7 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {
@@ -315,12 +315,12 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
       return result
     }
 
-    ao.cfg.domainPrefix = true
+    apm.cfg.domainPrefix = true
     let r
     try {
       r = customTransactionNameTest(custom)()
     } finally {
-      ao.cfg.domainPrefix = false
+      apm.cfg.domainPrefix = false
     }
     return r
   })
@@ -372,7 +372,7 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
         }
       })
 
-      ao.setCustomTxNameFunction('@hapi/hapi', custom)
+      apm.setCustomTxNameFunction('@hapi/hapi', custom)
 
       let _resolve
       const p = new Promise(function (resolve, reject) {
@@ -402,7 +402,7 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
             }
           }
 
-          if (ao.cfg.domainPrefix) {
+          if (apm.cfg.domainPrefix) {
             expectedCustom = customReq.headers.host + '/' + expectedCustom
           }
           msg.should.have.property('TransactionName', expectedCustom)
@@ -449,8 +449,8 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
         result = action
       }
 
-      if (ao.cfg.domainPrefix && what === 'tx') {
-        const prefix = ao.getDomainPrefix(request)
+      if (apm.cfg.domainPrefix && what === 'tx') {
+        const prefix = apm.getDomainPrefix(request)
         if (prefix) {
           result = prefix + '/' + result
         }

--- a/test/probes/@hapi/hapi.test.js
+++ b/test/probes/@hapi/hapi.test.js
@@ -7,7 +7,7 @@ const path = require('path')
 const helloDotEjs = 'hello.ejs'
 
 const helper = require(path.join(base, 'test/helper'))
-const apm = global[Symbol.for('SolarWinds.Apm.Once')]
+const apm = global[Symbol.for('solarwinds-apm')]
 
 const axios = require('axios')
 

--- a/test/probes/@hapi/vision.test.js
+++ b/test/probes/@hapi/vision.test.js
@@ -7,7 +7,7 @@ const path = require('path')
 const helloDotEjs = 'hello.ejs'
 
 const helper = require(path.join(base, 'test/helper'))
-const ao = global[Symbol.for('SolarWinds.Apm.Once')]
+const apm = global[Symbol.for('SolarWinds.Apm.Once')]
 
 const axios = require('axios')
 
@@ -31,14 +31,14 @@ describe(`probes.${visionName} ${pkg.version} ${hapiText}`, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.probes.fs.enabled = false
+    apm.probes.fs.enabled = false
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(done)
   })
 
@@ -213,7 +213,7 @@ describe(`probes.${visionName} ${pkg.version} ${hapiText}`, function () {
   }
 
   async function disabledTest () {
-    ao.probes['@hapi/vision'].enabled = false
+    apm.probes['@hapi/vision'].enabled = false
     const server = await makeViewServer()
 
     server.route({
@@ -244,7 +244,7 @@ describe(`probes.${visionName} ${pkg.version} ${hapiText}`, function () {
       }
     ]
     helper.doChecks(emitter, validations, function () {
-      ao.probes['@hapi/vision'].enabled = true
+      apm.probes['@hapi/vision'].enabled = true
       server.listener.close(_resolve)
     })
 
@@ -259,7 +259,7 @@ describe(`probes.${visionName} ${pkg.version} ${hapiText}`, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/@hapi/vision.test.js
+++ b/test/probes/@hapi/vision.test.js
@@ -7,7 +7,7 @@ const path = require('path')
 const helloDotEjs = 'hello.ejs'
 
 const helper = require(path.join(base, 'test/helper'))
-const apm = global[Symbol.for('SolarWinds.Apm.Once')]
+const apm = global[Symbol.for('solarwinds-apm')]
 
 const axios = require('axios')
 

--- a/test/probes/amqplib.test.js
+++ b/test/probes/amqplib.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common.js')
+const { apm } = require('../1.test-common.js')
 
 const pkg = require('amqplib/package')
 
@@ -47,9 +47,9 @@ describe('probes.amqplib ' + pkg.version, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
     emitter = helper.backend(done)
   })
   after(function (done) {
@@ -60,7 +60,7 @@ describe('probes.amqplib ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/aws-sdk.test.js
+++ b/test/probes/aws-sdk.test.js
@@ -1,7 +1,7 @@
 /* global it, describe */
 'use strict'
 
-const {ao} = require('../1.test-common.js'); // eslint-disable-line
+require('../1.test-common.js')
 const expect = require('chai').expect
 
 const aws = require('aws-sdk')

--- a/test/probes/bcrypt.test.js
+++ b/test/probes/bcrypt.test.js
@@ -1,7 +1,7 @@
 /* global it, describe, before, after */
 'use strict'
 
-const { ao, startTest, endTest } = require('../1.test-common.js')
+const { apm, startTest, endTest } = require('../1.test-common.js')
 const expect = require('chai').expect
 
 const bcrypt = require('bcrypt')
@@ -11,14 +11,14 @@ describe('probes.bcrypt ' + pkg.version, function () {
   let prevll
   before(function () {
     startTest(__filename, { enable: false, customFormatter: 'terse' })
-    prevll = ao.logLevel
-    // ao.logLevelAdd('span')
+    prevll = apm.logLevel
+    // apm.logLevelAdd('span')
   })
   after(function () {
-    // ao.requestStore.dumpCtx()
+    // apm.requestStore.dumpCtx()
 
     endTest()
-    ao.logLevel = prevll
+    apm.logLevel = prevll
   })
 
   it('should trace through async bcrypt', function (done) {
@@ -27,18 +27,18 @@ describe('probes.bcrypt ' + pkg.version, function () {
 
     process.env.DEBUG_CLS_HOOKED = 1
 
-    ao.startOrContinueTrace(
+    apm.startOrContinueTrace(
       '',
       '',
       'test-bcrypt',
       function (cb) {
-        ao.requestStore.set(test, 'bar')
+        apm.requestStore.set(test, 'bar')
         bcrypt.genSalt(10, function (err, salt) {
           bcrypt.hash(password, salt, function (err, hash) {
             bcrypt.compare(password, hash, function (err, res) {
               // the passwords should match
               res.should.equal(true)
-              const result = ao.requestStore.get(test)
+              const result = apm.requestStore.get(test)
               expect(result).equal('bar', 'context.get(foo) should equal bar')
               return cb()
             })

--- a/test/probes/cassandra-driver.test.js
+++ b/test/probes/cassandra-driver.test.js
@@ -2,17 +2,17 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao, startTest, endTest } = require('../1.test-common')
+const { apm, startTest, endTest } = require('../1.test-common')
 
 const noop = helper.noop
-const conf = ao.probes['cassandra-driver']
+const conf = apm.probes['cassandra-driver']
 
 const should = require('should') // eslint-disable-line no-unused-vars
 const hosts = helper.Address.from(
   process.env.SW_APM_TEST_CASSANDRA_2_2 || 'cassandra:9042'
 )
 
-const ks = 'test' + (process.env.AO_IX || '')
+const ks = 'test' + (process.env.apm_IX || '')
 
 if (helper.skipTest(module.filename)) {
   process.exit()
@@ -24,7 +24,7 @@ const pkg = require('cassandra-driver/package')
 
 describe('probes.cassandra-driver ' + pkg.version, function () {
   this.timeout(10000)
-  const ctx = { ao }
+  const ctx = { apm }
   let emitter
   let client
   let prevDebug
@@ -61,9 +61,9 @@ describe('probes.cassandra-driver ' + pkg.version, function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
@@ -116,20 +116,20 @@ describe('probes.cassandra-driver ' + pkg.version, function () {
   })
 
   beforeEach(function () {
-    prevDebug = ao.logLevel
+    prevDebug = apm.logLevel
     if (this.currentTest.title === 'should trace a prepared query') {
-      // ao.logLevel += ',test:messages'
+      // apm.logLevel += ',test:messages'
     }
   })
 
   afterEach(function () {
-    ao.logLevel = prevDebug
+    apm.logLevel = prevDebug
   })
 
   // test to work around UDP dropped message issue
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', noop)
+      apm.instrument('fake', noop)
       done()
     }, [
       function (msg) {
@@ -146,7 +146,7 @@ describe('probes.cassandra-driver ' + pkg.version, function () {
   })
 
   it('should be configured to not tag SQL by default', function () {
-    ao.probes.mysql.should.have.property('tagSql', false)
+    apm.probes.mysql.should.have.property('tagSql', false)
   })
 
   it('should trace a basic query', test_basic)
@@ -201,7 +201,7 @@ describe('probes.cassandra-driver ' + pkg.version, function () {
 
   function test_sanitize (done) {
     helper.test(emitter, function (done) {
-      const conf = ctx.ao.probes['cassandra-driver']
+      const conf = ctx.apm.probes['cassandra-driver']
       conf.sanitizeSql = true
       ctx.cassandra.execute("SELECT * from foo where bar='1'", function (err) {
         conf.sanitizeSql = false
@@ -317,7 +317,7 @@ describe('probes.cassandra-driver ' + pkg.version, function () {
   }
 
   function test_tag (done) {
-    ao.probes['cassandra-driver'].tagSql = true
+    apm.probes['cassandra-driver'].tagSql = true
 
     helper.test(emitter, function (done) {
       ctx.cassandra.execute('SELECT now() FROM system.local', done)

--- a/test/probes/co-render.test.js
+++ b/test/probes/co-render.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 // eslint-disable-next-line no-unused-vars
 const should = require('should')
@@ -32,23 +32,23 @@ describe(`probes/co-render ${pkg.version}`, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.probes.fs.enabled = false
+    apm.probes.fs.enabled = false
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(done)
-    ao.resetRequestStore()
+    apm.resetRequestStore()
   })
 
   // this test exists only to fix a problem with oboe not reporting a UDP
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/crypto.test.js
+++ b/test/probes/crypto.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const crypto = require('crypto')
 
@@ -34,9 +34,9 @@ describe('probes.crypto', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
@@ -46,7 +46,7 @@ describe('probes.crypto', function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/director.test.js
+++ b/test/probes/director.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const axios = require('axios')
 const http = require('http')
@@ -17,14 +17,14 @@ describe('probes.director ' + pkg.version, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.probes.fs.enabled = false
+    apm.probes.fs.enabled = false
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(done)
   })
 
@@ -51,7 +51,7 @@ describe('probes.director ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {
@@ -120,7 +120,7 @@ describe('probes.director ' + pkg.version, function () {
   })
 
   it('should skip when disabled', function (done) {
-    ao.probes.director.enabled = false
+    apm.probes.director.enabled = false
     function hello (name) {
       this.res.writeHead(200, { 'Content-Type': 'text/plain' })
       this.res.end('Hello, ' + name + '!')
@@ -150,7 +150,7 @@ describe('probes.director ' + pkg.version, function () {
       }
     ]
     helper.doChecks(emitter, validations, function () {
-      ao.probes.director.enabled = true
+      apm.probes.director.enabled = true
       server.close(done)
     })
 

--- a/test/probes/dns.test.js
+++ b/test/probes/dns.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const dns = require('dns')
 
@@ -34,9 +34,9 @@ describe('probes.dns', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
@@ -46,7 +46,7 @@ describe('probes.dns', function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -2,13 +2,13 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 const expect = require('chai').expect
 
 const path = require('path')
 const fs = require('fs')
 
-ao.probes.fs.collectBacktraces = false
+apm.probes.fs.collectBacktraces = false
 
 describe('probes.fs', function () {
   let emitter
@@ -18,7 +18,7 @@ describe('probes.fs', function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {
@@ -75,8 +75,8 @@ describe('probes.fs', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
   })
   after(function (done) {
     emitter.close(done)
@@ -537,10 +537,10 @@ describe('probes.fs', function () {
   })
 
   it('should fail openSync calls gracefully', function (done) {
-    const previousIgnoreErrors = ao.probes.fs.ignoreErrors
-    delete ao.probes.fs.ignoreErrors
+    const previousIgnoreErrors = apm.probes.fs.ignoreErrors
+    delete apm.probes.fs.ignoreErrors
     function reset (err) {
-      ao.probes.fs.ignoreErrors = previousIgnoreErrors
+      apm.probes.fs.ignoreErrors = previousIgnoreErrors
       done(err)
     }
     helper.test(emitter, function (done) {
@@ -564,10 +564,10 @@ describe('probes.fs', function () {
   })
 
   it('should suppress openSync errors when requested', function (done) {
-    const previousIgnoreErrors = ao.probes.fs.ignoreErrors
-    ao.probes.fs.ignoreErrors = { open: { ENOENT: true } }
+    const previousIgnoreErrors = apm.probes.fs.ignoreErrors
+    apm.probes.fs.ignoreErrors = { open: { ENOENT: true } }
     function reset (err) {
-      ao.probes.fs.ignoreErrors = previousIgnoreErrors
+      apm.probes.fs.ignoreErrors = previousIgnoreErrors
       done(err)
     }
     helper.test(emitter, function (done) {
@@ -591,10 +591,10 @@ describe('probes.fs', function () {
   })
 
   it('should suppress statSync errors when requested', function (done) {
-    const previousIgnoreErrors = ao.probes.fs.ignoreErrors
-    ao.probes.fs.ignoreErrors = { stat: { ENOENT: true } }
+    const previousIgnoreErrors = apm.probes.fs.ignoreErrors
+    apm.probes.fs.ignoreErrors = { stat: { ENOENT: true } }
     function reset (err) {
-      ao.probes.fs.ignoreErrors = previousIgnoreErrors
+      apm.probes.fs.ignoreErrors = previousIgnoreErrors
       done(err)
     }
     helper.test(emitter, function (done) {
@@ -618,10 +618,10 @@ describe('probes.fs', function () {
   })
 
   it('should report open errors', function (done) {
-    const previousIgnoreErrors = ao.probes.fs.ignoreErrors
-    delete ao.probes.fs.ignoreErrors
+    const previousIgnoreErrors = apm.probes.fs.ignoreErrors
+    delete apm.probes.fs.ignoreErrors
     function reset (err) {
-      ao.probes.fs.ignoreErrors = previousIgnoreErrors
+      apm.probes.fs.ignoreErrors = previousIgnoreErrors
       done(err)
     }
     helper.test(emitter, function (done) {
@@ -644,10 +644,10 @@ describe('probes.fs', function () {
   })
 
   it('should suppress open errors when requested', function (done) {
-    const previousIgnoreErrors = ao.probes.fs.ignoreErrors
-    ao.probes.fs.ignoreErrors = { open: { ENOENT: true } }
+    const previousIgnoreErrors = apm.probes.fs.ignoreErrors
+    apm.probes.fs.ignoreErrors = { open: { ENOENT: true } }
     function reset (err) {
-      ao.probes.fs.ignoreErrors = previousIgnoreErrors
+      apm.probes.fs.ignoreErrors = previousIgnoreErrors
       done(err)
     }
     helper.test(emitter, function (done) {
@@ -670,10 +670,10 @@ describe('probes.fs', function () {
   })
 
   it('should suppress stat errors when requested', function (done) {
-    const previousIgnoreErrors = ao.probes.fs.ignoreErrors
-    ao.probes.fs.ignoreErrors = { stat: { ENOENT: true } }
+    const previousIgnoreErrors = apm.probes.fs.ignoreErrors
+    apm.probes.fs.ignoreErrors = { stat: { ENOENT: true } }
     function reset (err) {
-      ao.probes.fs.ignoreErrors = previousIgnoreErrors
+      apm.probes.fs.ignoreErrors = previousIgnoreErrors
       done(err)
     }
     helper.test(emitter, function (done) {

--- a/test/probes/http-trigger-trace.test.js
+++ b/test/probes/http-trigger-trace.test.js
@@ -2,11 +2,11 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 const expect = require('chai').expect
-const addon = ao.addon
-const aob = addon
-const testdebug = ao.logger.make('testdebug')
+const addon = apm.addon
+const apmb = addon
+const testdebug = apm.logger.make('testdebug')
 
 const http = require('http')
 const axios = require('axios')
@@ -275,7 +275,7 @@ function makeSignedHeaders (test) {
 
   // add an headers with appropriate sample bit if requested
   if ('outHeaders' in test) {
-    const traceparent = ao.addon.Event.makeRandom(test.outHeaders).toString()
+    const traceparent = apm.addon.Event.makeRandom(test.outHeaders).toString()
     headers.traceparent = traceparent
     headers.tracestate = `sw=${traceparent.split('-')[2]}-${traceparent.split('-')[3]}`
   }
@@ -287,19 +287,19 @@ function makeSignedHeaders (test) {
 // helpers to disable/restore trigger-tracing and tracing
 //
 function disableTT () {
-  erStack.push(ao.cfg.triggerTraceEnabled)
-  ao.cfg.triggerTraceEnabled = false
+  erStack.push(apm.cfg.triggerTraceEnabled)
+  apm.cfg.triggerTraceEnabled = false
 }
 function restoreTT () {
-  ao.cfg.triggerTraceEnabled = erStack.pop()
+  apm.cfg.triggerTraceEnabled = erStack.pop()
 }
 
 function disableTracing () {
-  erStack.push(ao.traceMode)
-  ao.traceMode = 'disabled'
+  erStack.push(apm.traceMode)
+  apm.traceMode = 'disabled'
 }
 function restoreTracing () {
-  ao.traceMode = erStack.pop()
+  apm.traceMode = erStack.pop()
 }
 
 // helper to force rate-exceeded return
@@ -316,7 +316,7 @@ function restoreTracing () {
 //  const results = [];
 //
 //  while (counter++ < 100) {
-//    const settings = ao.addon.Settings.getTraceSettings('', options);
+//    const settings = apm.addon.Settings.getTraceSettings('', options);
 //    results.push(settings.status);
 //    if (settings.status !== 0) {
 //      console.log(settings.status, settings.message);
@@ -327,9 +327,9 @@ function restoreTracing () {
 
 // helper to wrap getTraceSettings()
 function wrapGTS () {
-  const realGetTraceSettings = ao.getTraceSettings
+  const realGetTraceSettings = apm.getTraceSettings
   erStack.push(realGetTraceSettings)
-  ao.getTraceSettings = function wrappedGetTraceSettings (...args) {
+  apm.getTraceSettings = function wrappedGetTraceSettings (...args) {
     const settings = realGetTraceSettings(...args)
     if (settings.status > 0) {
       return settings
@@ -339,12 +339,12 @@ function wrapGTS () {
     settings.doSample = false
     settings.doMetrics = false
     // the event that getTraceSettings returned isn't important.
-    settings.traceTaskId = aob.Event.makeRandom(0)
+    settings.traceTaskId = apmb.Event.makeRandom(0)
     return settings
   }
 }
 function unwrapGTS () {
-  ao.getTraceSettings = erStack.pop()
+  apm.getTraceSettings = erStack.pop()
 }
 
 //
@@ -356,11 +356,11 @@ describe('probes.http trigger-trace', function () {
   before(function (done) {
     // setup to handle messages
     emitter = helper.backend(done)
-    ao.sampleRate = addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
 
     // set the testing context for debugging tests.
-    ao.g.testing(__filename)
+    apm.g.testing(__filename)
   })
 
   let options
@@ -390,7 +390,7 @@ describe('probes.http trigger-trace', function () {
     emitter.close(done)
   })
   after(function () {
-    testdebug(`enters ${ao.Span.entrySpanEnters} exits ${ao.Span.entrySpanExits}`)
+    testdebug(`enters ${apm.Span.entrySpanEnters} exits ${apm.Span.entrySpanExits}`)
   })
 
   // from test/http.test.js
@@ -410,7 +410,7 @@ describe('probes.http trigger-trace', function () {
   // would be nice if oboe had a udp-counter.
   it('should do it\'s UDP thing', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () {})
+      apm.instrument('fake', function () {})
       done()
     }, [
       function (msg) {

--- a/test/probes/http-websocket-common.js
+++ b/test/probes/http-websocket-common.js
@@ -8,8 +8,8 @@
 //
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
-const addon = ao.addon
+const { apm } = require('../1.test-common')
+const addon = apm.addon
 
 const Url = require('url')
 const expect = require('chai').expect
@@ -36,15 +36,15 @@ const options = p === 'https' ? httpsOptions : {}
 
 describe(`probes.${p} websocket`, function () {
   let emitter
-  const previousHttpEnabled = ao.probes[p].enabled
-  const previousHttpClientEnabled = ao.probes[`${p}-client`].enabled
+  const previousHttpEnabled = apm.probes[p].enabled
+  const previousHttpClientEnabled = apm.probes[`${p}-client`].enabled
   let clear
   let originalFlag
 
   before(function (done) {
-    ao.sampleRate = addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
     // intercept message for analysis
     emitter = helper.backend(done)
   })
@@ -52,7 +52,7 @@ describe(`probes.${p} websocket`, function () {
     emitter.close(done)
   })
   after(function () {
-    ao.loggers.debug(`enters ${ao.Span.entrySpanEnters} exits ${ao.Span.entrySpanExits}`)
+    apm.loggers.debug(`enters ${apm.Span.entrySpanEnters} exits ${apm.Span.entrySpanExits}`)
   })
 
   //
@@ -67,8 +67,8 @@ describe(`probes.${p} websocket`, function () {
 
   beforeEach(function () {
     if (this.currentTest.title === `should not report anything when ${p} probe is disabled`) {
-      ao.probes[p].enabled = false
-      ao.probes[`${p}-client`].enabled = false
+      apm.probes[p].enabled = false
+      apm.probes[`${p}-client`].enabled = false
     } else if (this.currentTest.title === 'should trace correctly within asyncrony') {
       // this.skip()
     } else if (this.currentTest.title === 'should not send a span or metrics when there is a filter for it') {
@@ -78,10 +78,10 @@ describe(`probes.${p} websocket`, function () {
 
   afterEach(function () {
     if (this.currentTest.title === `should not report anything when ${p} probe is disabled`) {
-      ao.probes[p].enabled = previousHttpEnabled
-      ao.probes[`${p}-client`].enabled = previousHttpClientEnabled
+      apm.probes[p].enabled = previousHttpEnabled
+      apm.probes[`${p}-client`].enabled = previousHttpClientEnabled
     } else if (this.currentTest.title === 'should not send a span when there is a filter for it') {
-      ao.specialUrls = undefined
+      apm.specialUrls = undefined
     }
   })
   afterEach(function () {
@@ -149,17 +149,17 @@ describe(`probes.${p} websocket`, function () {
 
   describe(`${p}-client`, function () {
     // eslint-disable-next-line no-unused-vars
-    const conf = ao.probes[p]
+    const conf = apm.probes[p]
 
     after(function () {
-      ao.resetRequestStore()
+      apm.resetRequestStore()
     })
 
     // it's possible for a local UDP send to fail but oboe doesn't report
     // it, so compensate for it.
     it('UDP might lose a message running locally', function (done) {
       helper.test(emitter, function (done) {
-        ao.instrument('fake', function () {})
+        apm.instrument('fake', function () {})
         done()
       }, [
         function (msg) {

--- a/test/probes/koa-resource-router.test.js
+++ b/test/probes/koa-resource-router.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const pkg = require('koa-resource-router/package')
 
@@ -23,14 +23,14 @@ describe('probes/koa-resource-router ' + pkg.version, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.probes.fs.enabled = false
+    apm.probes.fs.enabled = false
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(done)
   })
 
@@ -38,7 +38,7 @@ describe('probes/koa-resource-router ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/koa-route.test.js
+++ b/test/probes/koa-route.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const pkg = require('koa-route/package')
 
@@ -23,14 +23,14 @@ describe('probes/koa-route ' + pkg.version, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.probes.fs.enabled = false
+    apm.probes.fs.enabled = false
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(done)
   })
 
@@ -38,7 +38,7 @@ describe('probes/koa-route ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/koa-router.test.js
+++ b/test/probes/koa-router.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common.js')
+const { apm } = require('../1.test-common.js')
 
 const semver = require('semver')
 const pkg = require('koa-router/package')
@@ -22,15 +22,15 @@ describe('probes/koa-router ' + pkg.version, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.probes.fs.enabled = false
+    apm.probes.fs.enabled = false
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
 
-    ao.g.testing(__filename)
+    apm.g.testing(__filename)
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
 
     emitter.close(done)
   })
@@ -39,7 +39,7 @@ describe('probes/koa-router ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/koa.js
+++ b/test/probes/koa.js
@@ -11,7 +11,7 @@ const koaRouterVersion = require('koa-router/package.json').version
 const helper = require('../helper')
 const axios = require('axios')
 
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const views = require('co-views')
 
@@ -121,7 +121,7 @@ exports.basic = function (emitter, done) {
 }
 
 exports.disabled = function (emitter, done) {
-  ao.probes.koa.enabled = false
+  apm.probes.koa.enabled = false
   const app = koa()
 
   app.use(function * () {
@@ -132,7 +132,7 @@ exports.disabled = function (emitter, done) {
     function (msg) { check['http-entry'](msg) },
     function (msg) { check['http-exit'](msg) }
   ], function () {
-    ao.probes.koa.enabled = true
+    apm.probes.koa.enabled = true
     server.close(done)
   })
 
@@ -168,7 +168,7 @@ exports.route = function (emitter, done) {
 }
 
 exports.route_disabled = function (emitter, done) {
-  ao.probes['koa-route'].enabled = false
+  apm.probes['koa-route'].enabled = false
   const app = koa()
 
   app.use(_.get('/hello/:name', function * hello () {
@@ -181,7 +181,7 @@ exports.route_disabled = function (emitter, done) {
     function (msg) { check['koa-exit'](msg) },
     function (msg) { check['http-exit'](msg) }
   ], function () {
-    ao.probes['koa-route'].enabled = true
+    apm.probes['koa-route'].enabled = true
     server.close(done)
   })
 
@@ -282,7 +282,7 @@ exports.router_promise = function (emitter, done) {
 }
 
 exports.router_disabled = function (emitter, done) {
-  ao.probes['koa-router'].enabled = false
+  apm.probes['koa-router'].enabled = false
   const app = koa()
 
   function * hello () {
@@ -305,7 +305,7 @@ exports.router_disabled = function (emitter, done) {
     function (msg) { check['koa-exit'](msg) },
     function (msg) { check['http-exit'](msg) }
   ], function () {
-    ao.probes['koa-router'].enabled = true
+    apm.probes['koa-router'].enabled = true
     server.close(done)
   })
 
@@ -346,7 +346,7 @@ exports.resourceRouter = function (emitter, done) {
 }
 
 exports.resourceRouter_disabled = function (emitter, done) {
-  ao.probes['koa-resource-router'].enabled = false
+  apm.probes['koa-resource-router'].enabled = false
   const app = koa()
 
   const res = new Resource('hello', {
@@ -363,7 +363,7 @@ exports.resourceRouter_disabled = function (emitter, done) {
     function (msg) { check['koa-exit'](msg) },
     function (msg) { check['http-exit'](msg) }
   ], function () {
-    ao.probes['koa-resource-router'].enabled = true
+    apm.probes['koa-resource-router'].enabled = true
     server.close(done)
   })
 
@@ -416,8 +416,8 @@ exports.render = function (emitter, done) {
 }
 
 exports.render_disabled = function (emitter, done) {
-  ao.probes['co-render'].enabled = false
-  ao.probes['http-client'].enabled = false
+  apm.probes['co-render'].enabled = false
+  apm.probes['http-client'].enabled = false
   const app = koa()
 
   app.use(function * () {
@@ -442,8 +442,8 @@ exports.render_disabled = function (emitter, done) {
   ]
 
   helper.doChecks(emitter, validations, function () {
-    ao.probes['co-render'].enabled = true
-    ao.probes['http-client'].enabled = true
+    apm.probes['co-render'].enabled = true
+    apm.probes['http-client'].enabled = true
     server.close(done)
   })
 

--- a/test/probes/koa.test.js
+++ b/test/probes/koa.test.js
@@ -2,8 +2,8 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
-ao.g.testing(__filename)
+const { apm } = require('../1.test-common')
+apm.g.testing(__filename)
 
 const assert = require('assert')
 
@@ -27,13 +27,13 @@ describe('probes/koa ' + pkg.version, function () {
   // Intercept messages for analysis
   //
   before(function (done) {
-    ao.probes.fs.enabled = false
+    apm.probes.fs.enabled = false
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(done)
   })
 
@@ -41,7 +41,7 @@ describe('probes/koa ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/level.test.js
+++ b/test/probes/level.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const fs = require('fs')
 // require level in order to test levelup/leveldown because level
@@ -29,9 +29,9 @@ describe('probes.level ' + pkg.version, function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
@@ -47,7 +47,7 @@ describe('probes.level ' + pkg.version, function () {
       }
       fs.rmdir(dbPath, done)
     } catch (e) {
-      ao.loggers.debug(`failed to rm -rf ${dbPath}`, e)
+      apm.loggers.debug(`failed to rm -rf ${dbPath}`, e)
       done()
     }
   })
@@ -67,7 +67,7 @@ describe('probes.level ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/log4js.test.js
+++ b/test/probes/log4js.test.js
@@ -1,7 +1,7 @@
 /* global it, describe, before, beforeEach, afterEach */
 'use strict'
 
-const ao = require('../..')
+const apm = require('../..')
 
 const helper = require('../helper')
 const expect = require('chai').expect
@@ -87,10 +87,10 @@ describe(`log4js v${version}`, function () {
   // Intercept messages for analysis
   //
   beforeEach(function (done) {
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.cfg.insertTraceIdsIntoLogs = true
-    ao.probes.fs.enabled = false
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.cfg.insertTraceIdsIntoLogs = true
+    apm.probes.fs.enabled = false
 
     emitter = helper.backend(done)
   })
@@ -102,7 +102,7 @@ describe(`log4js v${version}`, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () {})
+      apm.instrument('fake', function () {})
       done()
     }, [
       function (msg) {
@@ -132,7 +132,7 @@ describe(`log4js v${version}`, function () {
       const message = `synchronous traced setting = ${mode}`
       let traceId
 
-      ao.cfg.insertTraceIdsIntoLogs = mode
+      apm.cfg.insertTraceIdsIntoLogs = mode
 
       function localDone () {
         checkEventInfo(eventInfo, level, message, mode === false ? undefined : traceId)
@@ -140,8 +140,8 @@ describe(`log4js v${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.lastEvent.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.lastEvent.toString()
           // log
           logger.info(message)
         })
@@ -168,19 +168,19 @@ describe(`log4js v${version}`, function () {
       let traceId
 
       // these are reset in beforeEach() so set in each test.
-      ao.cfg.insertTraceIdsIntoLogs = mode
-      ao.traceMode = 0
-      ao.sampleRate = 0
+      apm.cfg.insertTraceIdsIntoLogs = mode
+      apm.traceMode = 0
+      apm.sampleRate = 0
 
       function test () {
-        traceId = ao.lastEvent.toString()
+        traceId = apm.lastEvent.toString()
         expect(traceId[traceId.length - 1] === '0', 'traceId should be unsampled')
         logger.info(message)
         return 'test-done'
       }
 
-      const traceparent = ao.addon.Event.makeRandom(0).toString()
-      const result = ao.startOrContinueTrace(traceparent, '', spanName, test)
+      const traceparent = apm.addon.Event.makeRandom(0).toString()
+      const result = apm.startOrContinueTrace(traceparent, '', spanName, test)
 
       expect(result).equal('test-done')
       checkEventInfo(eventInfo, level, message, maybe ? undefined : traceId)
@@ -191,7 +191,7 @@ describe(`log4js v${version}`, function () {
     const level = 'info'
     const message = 'always insert'
 
-    ao.cfg.insertTraceIdsIntoLogs = 'always'
+    apm.cfg.insertTraceIdsIntoLogs = 'always'
 
     logger.info(message)
 
@@ -209,7 +209,7 @@ describe(`log4js v${version}`, function () {
     }
 
     function asyncFunction (cb) {
-      traceId = ao.lastEvent.toString()
+      traceId = apm.lastEvent.toString()
       logger.error(message)
       setTimeout(function () {
         cb()
@@ -217,7 +217,7 @@ describe(`log4js v${version}`, function () {
     }
 
     helper.test(emitter, function (done) {
-      ao.instrument(spanName, asyncFunction, done)
+      apm.instrument(spanName, asyncFunction, done)
     }, [
       function (msg) {
         msg.should.have.property('Layer', spanName)
@@ -242,7 +242,7 @@ describe(`log4js v${version}`, function () {
     }
 
     function promiseFunction () {
-      traceId = ao.lastEvent.toString()
+      traceId = apm.lastEvent.toString()
       logger[level](message)
       return new Promise((resolve, reject) => {
         setTimeout(function () {
@@ -254,7 +254,7 @@ describe(`log4js v${version}`, function () {
     helper.test(
       emitter,
       function (done) {
-        ao.pInstrument(spanName, promiseFunction).then(r => {
+        apm.pInstrument(spanName, promiseFunction).then(r => {
           expect(r).equal(result)
           done()
         })
@@ -272,7 +272,7 @@ describe(`log4js v${version}`, function () {
 
   it('should insert trace IDs using the function directly', function (done) {
     const level = 'info'
-    ao.cfg.insertTraceIdsIntoLogs = false
+    apm.cfg.insertTraceIdsIntoLogs = false
     const message = 'helper and synchronous %s'
     let traceId
 
@@ -285,8 +285,8 @@ describe(`log4js v${version}`, function () {
     helper.test(
       emitter,
       function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.lastEvent.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.lastEvent.toString()
           logger[level](message, traceId)
         })
         done()
@@ -357,7 +357,7 @@ describe(`log4js v${version}`, function () {
       let level
       let traceId
 
-      ao.cfg.insertTraceIdsIntoLogs = true
+      apm.cfg.insertTraceIdsIntoLogs = true
 
       log4js.configure(config)
       const logger = log4js.getLogger()
@@ -368,8 +368,8 @@ describe(`log4js v${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.lastEvent.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.lastEvent.toString()
           // log
           level = typeof logger.custom === 'function' ? 'custom' : 'error'
           if (config.appenders.out.layout && config.appenders.out.layout.type === 'messagePassThrough') {
@@ -441,7 +441,7 @@ describe(`log4js v${version}`, function () {
       const message = 'layout testing'
       let level
 
-      ao.cfg.insertTraceIdsIntoLogs = true
+      apm.cfg.insertTraceIdsIntoLogs = true
 
       log4js.configure(config)
       const logger = log4js.getLogger()
@@ -452,7 +452,7 @@ describe(`log4js v${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
+        apm.instrument(spanName, function () {
           // log
           logger.error('Cheese is too ripe!')
         })
@@ -474,7 +474,7 @@ describe(`log4js v${version}`, function () {
     const message = 'addLayout testing'
     let level
 
-    ao.cfg.insertTraceIdsIntoLogs = true
+    apm.cfg.insertTraceIdsIntoLogs = true
 
     log4js.configure({
       appenders: {
@@ -497,7 +497,7 @@ describe(`log4js v${version}`, function () {
     }
 
     helper.test(emitter, function (done) {
-      ao.instrument(spanName, function () {
+      apm.instrument(spanName, function () {
         // log
         logger.info(message)
       })
@@ -518,7 +518,7 @@ describe(`log4js v${version}`, function () {
     const message = 'addLayout testing'
     let level
 
-    ao.cfg.insertTraceIdsIntoLogs = true
+    apm.cfg.insertTraceIdsIntoLogs = true
 
     log4js.addLayout('json', function (config) {
       return function (logEvent) { return JSON.stringify(logEvent) + config.separator }
@@ -540,7 +540,7 @@ describe(`log4js v${version}`, function () {
     }
 
     helper.test(emitter, function (done) {
-      ao.instrument(spanName, function () {
+      apm.instrument(spanName, function () {
         // log
         logger.info(message)
       })
@@ -562,7 +562,7 @@ describe(`log4js v${version}`, function () {
     let level
     let traceId
 
-    ao.cfg.insertTraceIdsIntoLogs = true
+    apm.cfg.insertTraceIdsIntoLogs = true
 
     log4js.configure({
       appenders: {
@@ -578,7 +578,7 @@ describe(`log4js v${version}`, function () {
     })
     const logger = log4js.getLogger()
     logger.addContext('user', 'charlie')
-    logger.addContext('trace', function () { return ao.getTraceStringForLog() })
+    logger.addContext('trace', function () { return apm.getTraceStringForLog() })
 
     function localDone () {
       checkEventInfo(eventInfo, level, message, traceId)
@@ -586,8 +586,8 @@ describe(`log4js v${version}`, function () {
     }
 
     helper.test(emitter, function (done) {
-      ao.instrument(spanName, function () {
-        traceId = ao.lastEvent.toString()
+      apm.instrument(spanName, function () {
+        traceId = apm.lastEvent.toString()
         // log
         logger.info(message)
       })
@@ -608,11 +608,11 @@ describe(`log4js v${version}`, function () {
     const message = 'addLayout testing'
     let traceId
 
-    ao.cfg.insertTraceIdsIntoLogs = true
+    apm.cfg.insertTraceIdsIntoLogs = true
 
     log4js.addLayout('json', function (config) {
       return function (logEvent) {
-        logEvent.context = { ...logEvent.context, sw: ao.getTraceObjectForLog() }
+        logEvent.context = { ...logEvent.context, sw: apm.getTraceObjectForLog() }
         return JSON.stringify(logEvent)
       }
     })
@@ -638,8 +638,8 @@ describe(`log4js v${version}`, function () {
     }
 
     helper.test(emitter, function (done) {
-      ao.instrument(spanName, function () {
-        traceId = ao.lastEvent.toString()
+      apm.instrument(spanName, function () {
+        traceId = apm.lastEvent.toString()
         // log
         logger.info(message)
       })
@@ -661,7 +661,7 @@ describe(`log4js v${version}`, function () {
     let level
     let traceId
 
-    ao.cfg.insertTraceIdsIntoLogs = true
+    apm.cfg.insertTraceIdsIntoLogs = true
 
     log4js.configure({
       appenders: {
@@ -675,7 +675,7 @@ describe(`log4js v${version}`, function () {
                 return 'Jake'
               },
               age: 45,
-              trace: function () { return ao.getTraceStringForLog() }
+              trace: function () { return apm.getTraceStringForLog() }
             }
           }
         }
@@ -690,8 +690,8 @@ describe(`log4js v${version}`, function () {
     }
 
     helper.test(emitter, function (done) {
-      ao.instrument(spanName, function () {
-        traceId = ao.lastEvent.toString()
+      apm.instrument(spanName, function () {
+        traceId = apm.lastEvent.toString()
         // log
         logger.info(message)
       })
@@ -713,8 +713,8 @@ describe(`log4js v${version}`, function () {
     const level = 'info'
     let traceId
 
-    ao.cfg.insertTraceIdsIntoLogs = true
-    ao.probes.express.enabled = false
+    apm.cfg.insertTraceIdsIntoLogs = true
+    apm.probes.express.enabled = false
     const express = require('express')
     const axios = require('axios')
 
@@ -727,7 +727,7 @@ describe(`log4js v${version}`, function () {
     app.get('/hello/:name', function (req, res) {
       // the trace id used by the middle ware is the one from the last event
       // which in this case comes from the express router
-      traceId = ao.lastEvent.toString()
+      traceId = apm.lastEvent.toString()
       res.render('hello', Object.create({
         name: req.params.name
       }))

--- a/test/probes/memcached.test.js
+++ b/test/probes/memcached.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const semver = require('semver')
 
@@ -20,10 +20,10 @@ describe('probes.memcached ' + pkg.version, function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
 
-    ao.g.testing(__filename)
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
@@ -55,7 +55,7 @@ describe('probes.memcached ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {
@@ -108,7 +108,7 @@ describe('probes.memcached ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {
@@ -273,11 +273,11 @@ describe('probes.memcached ' + pkg.version, function () {
   })
 
   it('should skip when disabled', function (done) {
-    ao.probes.memcached.enabled = false
+    apm.probes.memcached.enabled = false
     helper.test(emitter, function (done) {
       mem.get('foo', done)
     }, [], function (err) {
-      ao.probes.memcached.enabled = true
+      apm.probes.memcached.enabled = true
       done(err)
     })
   })

--- a/test/probes/mongodb-core.test.js
+++ b/test/probes/mongodb-core.test.js
@@ -2,10 +2,10 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common.js')
+const { apm } = require('../1.test-common.js')
 
 const noop = helper.noop
-const addon = ao.addon
+const addon = apm.addon
 
 const semver = require('semver')
 const mongodb = require('mongodb-core')
@@ -58,9 +58,9 @@ describe('probes.mongodb-core UDP', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
@@ -69,7 +69,7 @@ describe('probes.mongodb-core UDP', function () {
   // fake test to work around UDP dropped message issue
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', noop)
+      apm.instrument('fake', noop)
       done()
     }, [
       function (msg) {
@@ -104,16 +104,16 @@ function makeTests (db_host, host, isReplicaSet) {
   // Intercept messages for analysis
   //
   beforeEach(function (done) {
-    ao.probes.fs.enabled = false
-    ao.sampleRate = addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.probes[moduleName].collectBacktraces = false
+    apm.probes.fs.enabled = false
+    apm.sampleRate = addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.probes[moduleName].collectBacktraces = false
     emitter = helper.backend(function () {
       done()
     })
   })
   afterEach(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(function () {
       done()
     })
@@ -143,11 +143,11 @@ function makeTests (db_host, host, isReplicaSet) {
       'should count'
     ]
     if (doTheseTitles.length && doTheseTitles.indexOf(current.title) >= 0) {
-      // ao.logger.addEnabled('span');
+      // apm.logger.addEnabled('span');
     }
   })
   afterEach(function () {
-    // ao.logger.removeEnabled('span');
+    // apm.logger.removeEnabled('span');
   })
 
   //
@@ -164,7 +164,7 @@ function makeTests (db_host, host, isReplicaSet) {
       }
     })
 
-    ao.loggers.test.debug(`using dbn ${dbn}`)
+    apm.loggers.test.debug(`using dbn ${dbn}`)
 
     let server
     if (hosts.length > 1) {
@@ -289,7 +289,7 @@ function makeTests (db_host, host, isReplicaSet) {
           db.command(`${dbn}.$cmd`, { create: cn },
             function (e, data) {
               if (e) {
-                ao.loggers.error(`error creating "${cn}"`, e)
+                apm.loggers.error(`error creating "${cn}"`, e)
                 done(e)
                 return
               }
@@ -327,7 +327,7 @@ function makeTests (db_host, host, isReplicaSet) {
             },
             function (e, data) {
               if (e) {
-                ao.loggers.debug(`error renaming "${cn}" to "${dbn}.coll2-${dbn}"`, e)
+                apm.loggers.debug(`error renaming "${cn}" to "${dbn}.coll2-${dbn}"`, e)
                 done(e)
                 return
               }
@@ -359,7 +359,7 @@ function makeTests (db_host, host, isReplicaSet) {
           db.command(`${dbn}.$cmd`, { drop: `coll2-${dbn}` },
             function (e, data) {
               if (e) {
-                ao.loggers.debug(`error dropping "coll2-${dbn}`, e)
+                apm.loggers.debug(`error dropping "coll2-${dbn}`, e)
                 done(e)
                 return
               }

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -2,10 +2,10 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common.js')
+const { apm } = require('../1.test-common.js')
 
 const noop = helper.noop
-const addon = ao.addon
+const addon = apm.addon
 
 const semver = require('semver')
 const mongodb = require('mongodb')
@@ -55,9 +55,9 @@ describe('probes.mongodb UDP', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
@@ -66,7 +66,7 @@ describe('probes.mongodb UDP', function () {
   // fake test to work around UDP dropped message issue
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', noop)
+      apm.instrument('fake', noop)
       done()
     }, [
       function (msg) {
@@ -104,16 +104,16 @@ function makeTests (db_host, host, isReplicaSet) {
   // Intercept messages for analysis
   //
   beforeEach(function (done) {
-    ao.probes.fs.enabled = false
-    ao.sampleRate = addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.probes[moduleName].collectBacktraces = false
+    apm.probes.fs.enabled = false
+    apm.sampleRate = addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.probes[moduleName].collectBacktraces = false
     emitter = helper.backend(function () {
       done()
     })
   })
   afterEach(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(function () {
       done()
     })
@@ -143,11 +143,11 @@ function makeTests (db_host, host, isReplicaSet) {
       'should count'
     ]
     if (doTheseTitles.length && doTheseTitles.indexOf(current.title) >= 0) {
-      // ao.logger.addEnabled('span');
+      // apm.logger.addEnabled('span');
     }
   })
   afterEach(function () {
-    // ao.logger.removeEnabled('span');
+    // apm.logger.removeEnabled('span');
   })
 
   //
@@ -164,7 +164,7 @@ function makeTests (db_host, host, isReplicaSet) {
       }
     })
 
-    ao.loggers.test.debug(`using dbn ${dbn}`)
+    apm.loggers.test.debug(`using dbn ${dbn}`)
 
     let server
 
@@ -180,7 +180,7 @@ function makeTests (db_host, host, isReplicaSet) {
       const mongoClient = new MongoClient(server, {})
 
       mongoClient.connect((err, _client) => {
-        ao.loggers.test.debug('mongoClient() connect callback', err)
+        apm.loggers.test.debug('mongoClient() connect callback', err)
         if (err) {
           // eslint-disable-next-line no-console
           console.log('error connecting', err)
@@ -192,7 +192,7 @@ function makeTests (db_host, host, isReplicaSet) {
         ctx.collection = db.collection(cn)
 
         db.command({ dropDatabase: 1 }, function (err) {
-          ao.loggers.test.debug('before() dropDatabase callback', err)
+          apm.loggers.test.debug('before() dropDatabase callback', err)
           done()
         })
       })
@@ -209,7 +209,7 @@ function makeTests (db_host, host, isReplicaSet) {
       }
 
       mongoClient.connect((err, _client) => {
-        ao.loggers.test.debug('mongoClient() connect callback', err)
+        apm.loggers.test.debug('mongoClient() connect callback', err)
         if (err) {
           // eslint-disable-next-line no-console
           console.log('error connecting', err)
@@ -221,7 +221,7 @@ function makeTests (db_host, host, isReplicaSet) {
         ctx.collection = db.collection(cn)
 
         db.command({ dropDatabase: 1 }, function (err) {
-          ao.loggers.test.debug('before() dropDatabase callback', err)
+          apm.loggers.test.debug('before() dropDatabase callback', err)
           done()
         })
       })
@@ -314,7 +314,7 @@ function makeTests (db_host, host, isReplicaSet) {
           db.command({ create: cn },
             function (e, data) {
               if (e) {
-                ao.loggers.error(`error creating "${cn}"`, e)
+                apm.loggers.error(`error creating "${cn}"`, e)
                 done(e)
                 return
               }
@@ -355,7 +355,7 @@ function makeTests (db_host, host, isReplicaSet) {
             },
             function (e, data) {
               if (e) {
-                ao.loggers.debug(`error renaming "${cn}" to "${dbn}.coll2-${dbn}"`, e)
+                apm.loggers.debug(`error renaming "${cn}" to "${dbn}.coll2-${dbn}"`, e)
                 done(e)
                 return
               }
@@ -390,7 +390,7 @@ function makeTests (db_host, host, isReplicaSet) {
             { drop: `coll2-${dbn}` },
             function (e, data) {
               if (e) {
-                ao.loggers.debug(`error dropping "coll2-${dbn}`, e)
+                apm.loggers.debug(`error dropping "coll2-${dbn}`, e)
                 done(e)
                 return
               }

--- a/test/probes/mongoose.test.js
+++ b/test/probes/mongoose.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const expect = require('chai').expect
-const { ao } = require('../1.test-common.js')
+const { apm } = require('../1.test-common.js')
 const helper = require('../helper')
 const semver = require('semver')
 
@@ -42,7 +42,7 @@ describe(`probes/mongoose ${pkg.version} using ${moduleName}`, function () {
   let fsenabled
 
   before(function () {
-    ao.g.testing(__filename)
+    apm.g.testing(__filename)
   })
   after(function () {
   })
@@ -52,29 +52,29 @@ describe(`probes/mongoose ${pkg.version} using ${moduleName}`, function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
     // make them more readable
-    backtraces = ao.probes[moduleName].collectBacktraces
-    ao.probes[moduleName].collectBacktraces = false
+    backtraces = apm.probes[moduleName].collectBacktraces
+    apm.probes[moduleName].collectBacktraces = false
     // and don't let file IO complicate the results
-    fsenabled = ao.probes.fs.enabled
-    ao.probes.fs.enabled = false
-    ao.probes.dns.enabled = false
+    fsenabled = apm.probes.fs.enabled
+    apm.probes.fs.enabled = false
+    apm.probes.dns.enabled = false
   })
   after(function (done) {
-    ao.probes.fs.enabled = fsenabled
-    ao.probes[moduleName].collectBacktraces = backtraces
+    apm.probes.fs.enabled = fsenabled
+    apm.probes[moduleName].collectBacktraces = backtraces
     emitter.close(done)
   })
 
   beforeEach(function () {
     if (this.currentTest.title.indexOf('should connect and queue queries using a') === 0) {
-      // ao.logLevelAdd('test:messages')
+      // apm.logLevelAdd('test:messages')
     }
   })
   afterEach(function () {
-    // ao.logLevelRemove('test:messages')
+    // apm.logLevelRemove('test:messages')
   })
 
   //
@@ -104,7 +104,7 @@ describe(`probes/mongoose ${pkg.version} using ${moduleName}`, function () {
   // fake test to work around UDP dropped message issue
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () {})
+      apm.instrument('fake', function () {})
       done()
     }, [
       function (msg) {
@@ -308,7 +308,7 @@ describe(`probes/mongoose ${pkg.version} using ${moduleName}`, function () {
 
       mongoose.connect(`mongodb://${host}/${dbn}`, mongoOpts)
         .then(r => {
-          ao.loggers.test.debug('addQueue - connected')
+          apm.loggers.test.debug('addQueue - connected')
         })
 
       function makeInsertEntry (cat) {
@@ -381,17 +381,17 @@ describe(`probes/mongoose ${pkg.version} using ${moduleName}`, function () {
         }
       }
 
-      ao.g.stop = true
+      apm.g.stop = true
 
       helper.test(
         helper.setAggregate(emitter, aggregateSettings),
         function (done) {
           let n = 0
           function three () {
-            ao.loggers.test.debug('addQueue - three() %d', n + 1)
+            apm.loggers.test.debug('addQueue - three() %d', n + 1)
             if (++n >= 3) {
               mongoose.disconnect().then(r => {
-                ao.loggers.test.debug('disconnected')
+                apm.loggers.test.debug('disconnected')
                 done()
               })
             }
@@ -406,7 +406,7 @@ describe(`probes/mongoose ${pkg.version} using ${moduleName}`, function () {
         steps,
         function testDone (err, config) {
           if (!err) {
-            if (ao.loggers.test.debug.enabled) {
+            if (apm.loggers.test.debug.enabled) {
               config.messages.forEach(showMessage)
             }
             checkMessages(steps, config)

--- a/test/probes/morgan.test.js
+++ b/test/probes/morgan.test.js
@@ -5,7 +5,7 @@
 
 'use strict'
 
-const ao = require('../..')
+const apm = require('../..')
 
 const helper = require('../helper')
 const expect = require('chai').expect
@@ -115,7 +115,7 @@ describe(`probes.morgan ${version}`, function () {
   let eventInfo
 
   before(function () {
-    ao.probes.fs.enabled = false
+    apm.probes.fs.enabled = false
   })
 
   before(function () {
@@ -149,10 +149,10 @@ describe(`probes.morgan ${version}`, function () {
   //
   beforeEach(function (done) {
     // make sure we get sampled traces
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
     // default to the simple 'true'
-    ao.cfg.insertTraceIdsIntoLogs = true
+    apm.cfg.insertTraceIdsIntoLogs = true
 
     debugging = false
 
@@ -167,7 +167,7 @@ describe(`probes.morgan ${version}`, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () {})
+      apm.instrument('fake', function () {})
       done()
     }, [
       function (msg) {
@@ -188,7 +188,7 @@ describe(`probes.morgan ${version}`, function () {
       let traceId
 
       // this gets reset in beforeEach() so set it in the test.
-      ao.cfg.insertTraceIdsIntoLogs = mode
+      apm.cfg.insertTraceIdsIntoLogs = mode
       logger = makeLogger()
 
       function localDone () {
@@ -197,8 +197,8 @@ describe(`probes.morgan ${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.requestStore.get('topSpan').events.exit.event.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.requestStore.get('topSpan').events.exit.event.toString()
           // log
           logger(fakeReq, fakeRes, function (err) {
             expect(err).not.ok
@@ -230,10 +230,10 @@ describe(`probes.morgan ${version}`, function () {
       let traceId
 
       // reset in beforeEach() so set in each test.
-      ao.cfg.insertTraceIdsIntoLogs = mode
+      apm.cfg.insertTraceIdsIntoLogs = mode
       logger = makeLogger()
-      ao.traceMode = 0
-      ao.sampleRate = 0
+      apm.traceMode = 0
+      apm.sampleRate = 0
 
       function test () {
         // log
@@ -241,7 +241,7 @@ describe(`probes.morgan ${version}`, function () {
           expect(err).not.ok
           // let the listener run
           setImmediate(function () {
-            traceId = ao.lastEvent.toString()
+            traceId = apm.lastEvent.toString()
             expect(traceId[traceId.length - 1] === '0', 'traceId should be unsampled')
             checkEventInfo(eventInfo, fakeReq, fakeRes, maybe ? undefined : traceId)
             done()
@@ -254,8 +254,8 @@ describe(`probes.morgan ${version}`, function () {
         return 'test-done'
       }
 
-      const traceparent = ao.addon.Event.makeRandom(0).toString()
-      const result = ao.startOrContinueTrace(traceparent, '', spanName, test)
+      const traceparent = apm.addon.Event.makeRandom(0).toString()
+      const result = apm.startOrContinueTrace(traceparent, '', spanName, test)
       expect(result).equal('test-done')
     })
   })
@@ -273,7 +273,7 @@ describe(`probes.morgan ${version}`, function () {
         let traceId
 
         // this gets reset in beforeEach() so set it in the test.
-        ao.cfg.insertTraceIdsIntoLogs = mode
+        apm.cfg.insertTraceIdsIntoLogs = mode
         logger = makeLogger(predefined)
 
         function localDone () {
@@ -282,8 +282,8 @@ describe(`probes.morgan ${version}`, function () {
         }
 
         helper.test(emitter, function (done) {
-          ao.instrument(spanName, function () {
-            traceId = ao.requestStore.get('topSpan').events.exit.event.toString()
+          apm.instrument(spanName, function () {
+            traceId = apm.requestStore.get('topSpan').events.exit.event.toString()
             // log
             logger(fakeReq, fakeRes, function (err) {
               expect(err).not.ok
@@ -317,7 +317,7 @@ describe(`probes.morgan ${version}`, function () {
       let traceId
 
       // this gets reset in beforeEach() so set it in the test.
-      ao.cfg.insertTraceIdsIntoLogs = mode
+      apm.cfg.insertTraceIdsIntoLogs = mode
       logger = makeLogger('dev')
 
       function localDone () {
@@ -326,8 +326,8 @@ describe(`probes.morgan ${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.requestStore.get('topSpan').events.exit.event.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.requestStore.get('topSpan').events.exit.event.toString()
           // log
           logger(fakeReq, fakeRes, function (err) {
             expect(err).not.ok
@@ -360,7 +360,7 @@ describe(`probes.morgan ${version}`, function () {
       let traceId
 
       // this gets reset in beforeEach() so set it in the test.
-      ao.cfg.insertTraceIdsIntoLogs = mode
+      apm.cfg.insertTraceIdsIntoLogs = mode
       logger = makeLogger(':method :trace :url :status :res[content-length]')
 
       function localDone () {
@@ -369,8 +369,8 @@ describe(`probes.morgan ${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.requestStore.get('topSpan').events.exit.event.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.requestStore.get('topSpan').events.exit.event.toString()
           // log
           logger(fakeReq, fakeRes, function (err) {
             expect(err).not.ok
@@ -400,7 +400,7 @@ describe(`probes.morgan ${version}`, function () {
 
     it(`should never insert in sync when mode=${mode} using a format string and no insertion is requested`, function (done) {
       // this gets reset in beforeEach() so set it in the test.
-      ao.cfg.insertTraceIdsIntoLogs = mode
+      apm.cfg.insertTraceIdsIntoLogs = mode
       logger = makeLogger(':method :url :status :res[content-length]')
 
       function localDone () {
@@ -409,7 +409,7 @@ describe(`probes.morgan ${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
+        apm.instrument(spanName, function () {
           // log
           logger(fakeReq, fakeRes, function (err) {
             expect(err).not.ok
@@ -439,7 +439,7 @@ describe(`probes.morgan ${version}`, function () {
 
     it(`should never insert in sync when mode=${mode} using a format function`, function (done) {
       // this gets reset in beforeEach() so set it in the test.
-      ao.cfg.insertTraceIdsIntoLogs = mode
+      apm.cfg.insertTraceIdsIntoLogs = mode
       logger = makeLogger(function () { return 'xyzzy' })
 
       function localDone () {
@@ -448,7 +448,7 @@ describe(`probes.morgan ${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
+        apm.instrument(spanName, function () {
           // log
           logger(fakeReq, fakeRes, function (err) {
             expect(err).not.ok
@@ -481,7 +481,7 @@ describe(`probes.morgan ${version}`, function () {
       let traceId
 
       // this gets reset in beforeEach() so set it in the test.
-      ao.cfg.insertTraceIdsIntoLogs = mode
+      apm.cfg.insertTraceIdsIntoLogs = mode
       const custom = function (tokens, req, res) {
         return [
           tokens.trace(), // the token can be used as a method in custom function
@@ -500,8 +500,8 @@ describe(`probes.morgan ${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.requestStore.get('topSpan').events.exit.event.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.requestStore.get('topSpan').events.exit.event.toString()
           // log
           logger(fakeReq, fakeRes, function (err) {
             expect(err).not.ok
@@ -527,15 +527,15 @@ describe(`probes.morgan ${version}`, function () {
   // verify that mode 'always' inserts even when not tracing
   //
   it('mode=\'always\' should always insert a trace ID even if not tracing', function (done) {
-    ao.requestStore.run(function () {
+    apm.requestStore.run(function () {
       const traceId = `00-${'0'.repeat(32)}-${'0'.repeat(16)}-${'0'.repeat(2)}`
-      ao.lastEvent = undefined
+      apm.lastEvent = undefined
 
-      ao.cfg.insertTraceIdsIntoLogs = 'always'
+      apm.cfg.insertTraceIdsIntoLogs = 'always'
       logger = makeLogger()
-      ao.traceMode = 0
-      ao.sampleRate = 0
-      // console.log(ao.lastEvent);
+      apm.traceMode = 0
+      apm.sampleRate = 0
+      // console.log(apm.lastEvent);
 
       logger(fakeReq, fakeRes, function (err) {
         expect(err).not.ok
@@ -565,7 +565,7 @@ describe(`probes.morgan ${version}`, function () {
         expect(err).not.ok
       })
       setImmediate(function () {
-        traceId = ao.lastEvent.toString()
+        traceId = apm.lastEvent.toString()
         cb()
       })
       fakeRes.writeHead(200)
@@ -573,7 +573,7 @@ describe(`probes.morgan ${version}`, function () {
     }
 
     helper.test(emitter, function (done) {
-      ao.instrument(spanName, asyncFunction, done)
+      apm.instrument(spanName, asyncFunction, done)
     }, [
       function (msg) {
         msg.should.have.property('Layer', spanName)
@@ -597,7 +597,7 @@ describe(`probes.morgan ${version}`, function () {
     }
 
     function promiseFunction () {
-      traceId = ao.lastEvent.toString()
+      traceId = apm.lastEvent.toString()
       return new Promise((resolve, reject) => {
         logger(fakeReq, fakeRes, function (err) {
           expect(err).not.ok
@@ -611,7 +611,7 @@ describe(`probes.morgan ${version}`, function () {
     helper.test(
       emitter,
       function (done) {
-        ao.pInstrument(spanName, promiseFunction).then(r => {
+        apm.pInstrument(spanName, promiseFunction).then(r => {
           expect(r).equal(result)
           done()
         })
@@ -629,12 +629,12 @@ describe(`probes.morgan ${version}`, function () {
 
   it('should insert trace IDs using the function directly', function (done) {
     // test does not have last span - thus force a "zeroed" trace id
-    ao.cfg.insertTraceIdsIntoLogs = 'always'
+    apm.cfg.insertTraceIdsIntoLogs = 'always'
     let traceId
 
     logger = makeLogger('traceThis::my-trace-id')
 
-    morgan.token('my-trace-id', () => ao.getTraceStringForLog())
+    morgan.token('my-trace-id', () => apm.getTraceStringForLog())
 
     function localDone () {
       checkEventInfo(eventInfo, fakeReq, fakeRes, traceId)
@@ -644,8 +644,8 @@ describe(`probes.morgan ${version}`, function () {
     helper.test(
       emitter,
       function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.requestStore.get('topSpan').events.exit.event.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.requestStore.get('topSpan').events.exit.event.toString()
           logger(fakeReq, fakeRes, function (err) {
             expect(err).not.ok
           })

--- a/test/probes/mysql.test.js
+++ b/test/probes/mysql.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common.js')
+const { apm } = require('../1.test-common.js')
 
 const mysql = require('mysql')
 const pkg = require('mysql/package.json')
@@ -32,7 +32,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
     setTimeout(function () {
       done()
     }, 100)
-    ao.g.testing(__filename)
+    apm.g.testing(__filename)
   })
 
   //
@@ -40,25 +40,25 @@ describe(`probes.mysql ${pkg.version}`, function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.probes.fs.enabled = false
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.probes.fs.enabled = false
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(done)
   })
 
   let prevll
   beforeEach(function () {
     if (this.currentTest.title === 'should trace a streaming query') {
-      prevll = ao.logLevel
+      prevll = apm.logLevel
     }
   })
 
   afterEach(function () {
     if (this.currentTest.title === 'should trace a streaming query') {
-      ao.logLevel = prevll
+      apm.logLevel = prevll
     }
   })
 
@@ -104,7 +104,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
 
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', helper.noop)
+      apm.instrument('fake', helper.noop)
       done()
     }, [
       function (msg) {
@@ -127,7 +127,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
       // db.query('SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = \'test\';', function (err, data) {
       db.query('show databases like \'test\';', function (err, data) {
         if (err) {
-          ao.loggers.debug(err)
+          apm.loggers.debug(err)
           return done(err)
         }
         if (data.length) {
@@ -187,13 +187,13 @@ describe(`probes.mysql ${pkg.version}`, function () {
   })
 
   it('should be configured to sanitize SQL by default', function () {
-    ao.probes.mysql.should.have.property('sanitizeSql', true)
+    apm.probes.mysql.should.have.property('sanitizeSql', true)
     // turn off for testing
-    ao.probes.mysql.sanitizeSql = false
+    apm.probes.mysql.sanitizeSql = false
   })
 
   it('should be configured to not tag SQL by default', function () {
-    ao.probes.mysql.should.have.property('tagSql', false)
+    apm.probes.mysql.should.have.property('tagSql', false)
   })
 
   it('should trace a basic query', test_basic)
@@ -329,7 +329,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
 
   function test_sanitize (done) {
     helper.test(emitter, function (done) {
-      ao.probes.mysql.sanitizeSql = true
+      apm.probes.mysql.sanitizeSql = true
       const query = `SELECT * FROM ${ctx.t} WHERE "foo" = ` + mysql.escape('bar')
       ctx.mysql.query(query, done)
     }, [
@@ -341,7 +341,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
         checks.exit(msg)
       }
     ], () => {
-      ao.probes.mysql.sanitizeSql = false
+      apm.probes.mysql.sanitizeSql = false
       done()
     })
   }
@@ -368,7 +368,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
   }
 
   function test_tag (done) {
-    ao.probes.mysql.tagSql = true
+    apm.probes.mysql.tagSql = true
     helper.test(emitter, function (done) {
       const query = 'SELECT 1'
       ctx.mysql.query(query, done)
@@ -382,18 +382,18 @@ describe(`probes.mysql ${pkg.version}`, function () {
         checks.exit(msg)
       }
     ], () => {
-      ao.probes.mysql.tagSql = false
+      apm.probes.mysql.tagSql = false
       done()
     })
   }
 
   function test_disabled (done) {
-    ao.probes.mysql.enabled = false
+    apm.probes.mysql.enabled = false
     helper.test(emitter, function (done) {
       const query = 'SELECT 1'
       ctx.mysql.query(query, done)
     }, [], function (err) {
-      ao.probes.mysql.enabled = true
+      apm.probes.mysql.enabled = true
       done(err)
     })
   }

--- a/test/probes/oracledb.test.js
+++ b/test/probes/oracledb.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const oracledb = require('oracledb')
 const pkg = require('oracledb/package.json')
@@ -26,10 +26,10 @@ describe(`probes.oracledb ${pkg.version}`, function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
 
-    ao.g.testing(__filename)
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
@@ -44,7 +44,7 @@ describe(`probes.oracledb ${pkg.version}`, function () {
 
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {
@@ -55,12 +55,12 @@ describe(`probes.oracledb ${pkg.version}`, function () {
   })
 
   it('should be configured to sanitize SQL by default', function () {
-    ao.probes.oracledb.should.have.property('sanitizeSql', true)
-    ao.probes.oracledb.sanitizeSql = false
+    apm.probes.oracledb.should.have.property('sanitizeSql', true)
+    apm.probes.oracledb.sanitizeSql = false
   })
 
   it('should be configured to not tag SQL by default', function () {
-    ao.probes.oracledb.should.have.property('tagSql', false)
+    apm.probes.oracledb.should.have.property('tagSql', false)
   })
 
   const checks = {
@@ -111,7 +111,7 @@ describe(`probes.oracledb ${pkg.version}`, function () {
   function test_sanitization (done) {
     helper.test(emitter, function (done) {
       oracledb.isAutoCommit = false
-      ao.probes.oracledb.sanitizeSql = true
+      apm.probes.oracledb.sanitizeSql = true
 
       function query (err, connection) {
         if (err) {
@@ -131,7 +131,7 @@ describe(`probes.oracledb ${pkg.version}`, function () {
         checks['oracle-exit'](msg)
       }
     ], () => {
-      ao.probes.oracledb.sanitizeSql = false
+      apm.probes.oracledb.sanitizeSql = false
       done()
     })
   }
@@ -165,7 +165,7 @@ describe(`probes.oracledb ${pkg.version}`, function () {
   }
 
   function test_tag (done) {
-    ao.probes.oracledb.tagSql = true
+    apm.probes.oracledb.tagSql = true
     helper.test(emitter, function (done) {
       oracledb.isAutoCommit = false
       function query (err, connection) {
@@ -186,7 +186,7 @@ describe(`probes.oracledb ${pkg.version}`, function () {
         checks['oracle-exit'](msg)
       }
     ], () => {
-      ao.probes.oracledb.tagSql = false
+      apm.probes.oracledb.tagSql = false
       done()
     })
   }
@@ -280,7 +280,7 @@ describe(`probes.oracledb ${pkg.version}`, function () {
   }
 
   function test_disabled (done) {
-    ao.probes.oracledb.enabled = false
+    apm.probes.oracledb.enabled = false
 
     helper.test(emitter, function (done) {
       oracledb.isAutoCommit = false

--- a/test/probes/pg.test.js
+++ b/test/probes/pg.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const postgres = require('pg')
 const pkg = require('pg/package.json')
@@ -30,38 +30,38 @@ try {
   nativeVer = require('pg-native/package').version
   hasNative = true
 } catch (e) {
-  ao.loggers.test.info('test/probes/pg failed to load pg native')
+  apm.loggers.test.info('test/probes/pg failed to load pg native')
   hasNative = false
 }
 
 describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
   let emitter
-  const ctx = { ao, tName, addr }
+  const ctx = { apm, tName, addr }
 
   // note: perform this test before setting test context since we flip the setting from default to false.
   it('should be configured to sanitize SQL by default', function () {
-    ao.probes.pg.should.have.property('sanitizeSql', true)
-    ao.probes.pg.sanitizeSql = false
+    apm.probes.pg.should.have.property('sanitizeSql', true)
+    apm.probes.pg.sanitizeSql = false
   })
 
   it('should be configured to not tag SQL by default', function () {
-    ao.probes.pg.should.have.property('tagSql', false)
+    apm.probes.pg.should.have.property('tagSql', false)
   })
 
   //
   // Intercept messages for analysis
   //
   before(function (done) {
-    if (ao.lastEvent) {
-      const c = ao.requestStore.active ? ao.requestStore.active.id : null
-      ao.loggers.debug(`id ${c} event.last at startup %e`, ao.lastEvent)
+    if (apm.lastEvent) {
+      const c = apm.requestStore.active ? apm.requestStore.active.id : null
+      apm.loggers.debug(`id ${c} event.last at startup %e`, apm.lastEvent)
     }
 
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.probes.fs.enabled = false
-    ao.probes.dns.enabled = false
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.probes.fs.enabled = false
+    apm.probes.dns.enabled = false
   })
   after(function (done) {
     emitter.close(done)
@@ -71,17 +71,17 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
   // basic test setup and teardown
   //
   before(function () {
-    ao.g.testing(__filename)
+    apm.g.testing(__filename)
   })
   after(function () {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
   })
 
   //
   // remove any leftover context
   //
   after(function () {
-    ao.resetRequestStore()
+    apm.resetRequestStore()
   })
 
   //
@@ -115,7 +115,7 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
   //
   // Test against both native and js postgres drivers
   //
-  const subtests = require('./pg/subtests')(ao, ctx)
+  const subtests = require('./pg/subtests')(apm, ctx)
 
   Object.keys(drivers).forEach(function (type) {
     const driver = drivers[type]
@@ -154,7 +154,7 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
       // test to work around UDP dropped message issue
       it('UDP might lose a message', function (done) {
         helper.test(emitter, function (done) {
-          ao.instrument('fake', function () {})
+          apm.instrument('fake', function () {})
           done()
         }, [
           function (msg) {

--- a/test/probes/pg/subtests.js
+++ b/test/probes/pg/subtests.js
@@ -1,6 +1,6 @@
 'use strict'
 
-module.exports = function (ao, ctx) {
+module.exports = function (apm, ctx) {
   // common checks
   const checks = {
     entry: function (msg) {
@@ -144,12 +144,12 @@ module.exports = function (ao, ctx) {
 
   const cSanitizeText = 'should sanitize query when no value list using a callback'
   function cSanitize (done) {
-    ctx.ao.probes.pg.sanitizeSql = true
+    ctx.apm.probes.pg.sanitizeSql = true
 
     ctx.client.get().query(
       sanitizeQuery,
       function (err) {
-        ctx.ao.probes.pg.sanitizeSql = false
+        ctx.apm.probes.pg.sanitizeSql = false
         done()
       }
     )
@@ -157,15 +157,15 @@ module.exports = function (ao, ctx) {
 
   const pSanitizeText = 'should sanitize query when no value list using promises'
   function pSanitize (done) {
-    ctx.ao.probes.pg.sanitizeSql = true
+    ctx.apm.probes.pg.sanitizeSql = true
 
     ctx.client.get().query(sanitizeQuery)
       .then(res => {
-        ctx.ao.probes.pg.sanitizeSql = false
+        ctx.apm.probes.pg.sanitizeSql = false
         done()
       })
       .catch(e => {
-        ctx.ao.probes.pg.sanitizeSql = false
+        ctx.apm.probes.pg.sanitizeSql = false
         done()
       })
   }
@@ -236,23 +236,23 @@ module.exports = function (ao, ctx) {
 
   const cTagText = 'should tag queries when feature is enabledusing callback'
   function cTag (done) {
-    ctx.ao.probes.pg.tagSql = true
+    ctx.apm.probes.pg.tagSql = true
     ctx.client.get().query('SELECT $1::int AS number', ['1'], function () {
-      ctx.ao.probes.pg.tagSql = false
+      ctx.apm.probes.pg.tagSql = false
       done()
     })
   }
 
   const pTagText = 'should tag queries when feature is enabled using promises'
   function pTag (done) {
-    ctx.ao.probes.pg.tagSql = true
+    ctx.apm.probes.pg.tagSql = true
     ctx.client.get().query('SELECT $1::int AS number', ['1'])
       .then(results => {
-        ctx.ao.probes.pg.tagSql = false
+        ctx.apm.probes.pg.tagSql = false
         done()
       })
       .catch(e => {
-        ctx.ao.probes.pg.tagSql = false
+        ctx.apm.probes.pg.tagSql = false
         done(e)
       })
   }
@@ -270,23 +270,23 @@ module.exports = function (ao, ctx) {
 
   const cDisabledText = 'should do nothing when disabled using a callback'
   function cDisabled (done) {
-    ctx.ao.probes.pg.enabled = false
+    ctx.apm.probes.pg.enabled = false
     ctx.client.get().query('SELECT $1::int AS number', ['1'], function (err) {
-      ctx.ao.probes.pg.enabled = true
+      ctx.apm.probes.pg.enabled = true
       done(err)
     })
   }
 
   const pDisabledText = 'should do nothing when disabled using promises'
   function pDisabled (done) {
-    ctx.ao.probes.pg.enabled = false
+    ctx.apm.probes.pg.enabled = false
     ctx.client.get().query('SELECT $1::int AS number', ['1'])
       .then(results => {
-        ctx.ao.probes.pg.enabled = true
+        ctx.apm.probes.pg.enabled = true
         done()
       })
       .catch(e => {
-        ctx.ao.probes.pg.enabled = true
+        ctx.apm.probes.pg.enabled = true
         done(e)
       })
   }

--- a/test/probes/pino.test.js
+++ b/test/probes/pino.test.js
@@ -1,7 +1,7 @@
 /* global it, describe, before, beforeEach, afterEach */
 'use strict'
 
-const ao = require('../..')
+const apm = require('../..')
 
 const helper = require('../helper')
 const expect = require('chai').expect
@@ -128,10 +128,10 @@ describe(`pino v${version}`, function () {
   // Intercept messages for analysis
   //
   beforeEach(function (done) {
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.cfg.insertTraceIdsIntoLogs = true
-    ao.probes.fs.enabled = false
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.cfg.insertTraceIdsIntoLogs = true
+    apm.probes.fs.enabled = false
 
     emitter = helper.backend(done)
   })
@@ -143,7 +143,7 @@ describe(`pino v${version}`, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () {})
+      apm.instrument('fake', function () {})
       done()
     }, [
       function (msg) {
@@ -162,7 +162,7 @@ describe(`pino v${version}`, function () {
       const message = `synchronous traced setting = ${mode}`
       let traceId
 
-      ao.cfg.insertTraceIdsIntoLogs = mode
+      apm.cfg.insertTraceIdsIntoLogs = mode
 
       function localDone () {
         checkEventInfo(eventInfo, level, message, mode === false ? undefined : traceId)
@@ -170,8 +170,8 @@ describe(`pino v${version}`, function () {
       }
 
       helper.test(emitter, function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.lastEvent.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.lastEvent.toString()
           // log
           logger.info(message)
         })
@@ -198,19 +198,19 @@ describe(`pino v${version}`, function () {
       let traceId
 
       // these are reset in beforeEach() so set in each test.
-      ao.cfg.insertTraceIdsIntoLogs = mode
-      ao.traceMode = 0
-      ao.sampleRate = 0
+      apm.cfg.insertTraceIdsIntoLogs = mode
+      apm.traceMode = 0
+      apm.sampleRate = 0
 
       function test () {
-        traceId = ao.lastEvent.toString()
+        traceId = apm.lastEvent.toString()
         expect(traceId[traceId.length - 1] === '0', 'traceId shoud be unsampled')
         logger.info(message)
         return 'test-done'
       }
 
-      const traceparent = ao.addon.Event.makeRandom(0).toString()
-      const result = ao.startOrContinueTrace(traceparent, '', spanName, test)
+      const traceparent = apm.addon.Event.makeRandom(0).toString()
+      const result = apm.startOrContinueTrace(traceparent, '', spanName, test)
 
       expect(result).equal('test-done')
       checkEventInfo(eventInfo, level, message, maybe ? undefined : traceId)
@@ -221,7 +221,7 @@ describe(`pino v${version}`, function () {
     const level = 'info'
     const message = 'always insert'
 
-    ao.cfg.insertTraceIdsIntoLogs = 'always'
+    apm.cfg.insertTraceIdsIntoLogs = 'always'
 
     logger.info(message)
 
@@ -239,7 +239,7 @@ describe(`pino v${version}`, function () {
     }
 
     function asyncFunction (cb) {
-      traceId = ao.lastEvent.toString()
+      traceId = apm.lastEvent.toString()
       logger.error(message)
       setTimeout(function () {
         cb()
@@ -247,7 +247,7 @@ describe(`pino v${version}`, function () {
     }
 
     helper.test(emitter, function (done) {
-      ao.instrument(spanName, asyncFunction, done)
+      apm.instrument(spanName, asyncFunction, done)
     }, [
       function (msg) {
         msg.should.have.property('Layer', spanName)
@@ -272,7 +272,7 @@ describe(`pino v${version}`, function () {
     }
 
     function promiseFunction () {
-      traceId = ao.lastEvent.toString()
+      traceId = apm.lastEvent.toString()
       logger[level](message)
       return new Promise((resolve, reject) => {
         setTimeout(function () {
@@ -284,7 +284,7 @@ describe(`pino v${version}`, function () {
     helper.test(
       emitter,
       function (done) {
-        ao.pInstrument(spanName, promiseFunction).then(r => {
+        apm.pInstrument(spanName, promiseFunction).then(r => {
           expect(r).equal(result)
           done()
         })
@@ -302,7 +302,7 @@ describe(`pino v${version}`, function () {
 
   it('should insert trace IDs using the function directly', function (done) {
     const level = 'info'
-    ao.cfg.insertTraceIdsIntoLogs = false
+    apm.cfg.insertTraceIdsIntoLogs = false
     const message = 'helper and synchronous %s'
     let traceId
 
@@ -315,8 +315,8 @@ describe(`pino v${version}`, function () {
     helper.test(
       emitter,
       function (done) {
-        ao.instrument(spanName, function () {
-          traceId = ao.lastEvent.toString()
+        apm.instrument(spanName, function () {
+          traceId = apm.lastEvent.toString()
           logger[level](message, traceId)
         })
         done()

--- a/test/probes/promises/index.js
+++ b/test/probes/promises/index.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../../helper')
-const ao = helper.ao
+const apm = helper.apm
 const fs = require('fs')
 const should = require('should')
 
@@ -36,12 +36,12 @@ module.exports = function (Promise) {
 
   it('should support promises via delay', function (done) {
     const t = indirectDone(done)
-    ao.requestStore.run(function () {
-      ao.requestStore.set('foo', 'bar')
+    apm.requestStore.run(function () {
+      apm.requestStore.set('foo', 'bar')
       delay(100).then(function () {
         return delay(100)
       }).then(function () {
-        ao.requestStore.get('foo').should.equal('bar')
+        apm.requestStore.get('foo').should.equal('bar')
         t.done()
       }).catch(e => {
         // this shouldn't happen so check that it doesn't.
@@ -53,8 +53,8 @@ module.exports = function (Promise) {
 
   it('should support promises via fs.readFile', function (done) {
     const t = indirectDone(done)
-    ao.requestStore.run(function () {
-      ao.requestStore.set('foo', 'bar')
+    apm.requestStore.run(function () {
+      apm.requestStore.set('foo', 'bar')
       const p = new Promise(function (resolve, reject) {
         fs.readFile('./package.json', 'utf8', function (err, data) {
           if (err) {
@@ -65,7 +65,7 @@ module.exports = function (Promise) {
         })
       })
       p.then(function () {
-        ao.requestStore.get('foo').should.equal('bar')
+        apm.requestStore.get('foo').should.equal('bar')
         t.done()
       }).catch(e => {
         should.notExist(e)
@@ -78,10 +78,10 @@ module.exports = function (Promise) {
     const d = domain.create()
     d.on('error', done)
     d.run(function () {
-      ao.requestStore.run(function () {
-        ao.requestStore.set('foo', 'bar')
+      apm.requestStore.run(function () {
+        apm.requestStore.set('foo', 'bar')
         delay(100).then(function () {
-          const foo = ao.requestStore.get('foo')
+          const foo = apm.requestStore.get('foo')
           should.exist(foo)
           foo.should.equal('bar')
           t.done()
@@ -99,8 +99,8 @@ module.exports = function (Promise) {
 
   it('should support progress callbacks', function (done) {
     const t = indirectDone(done)
-    ao.requestStore.run(function () {
-      ao.requestStore.set('foo', 'bar')
+    apm.requestStore.run(function () {
+      apm.requestStore.set('foo', 'bar')
       delay(100).then(function () {
         t.done()
       }, done, function () {})

--- a/test/probes/q.test.js
+++ b/test/probes/q.test.js
@@ -1,13 +1,13 @@
 /* global describe, before */
 'use strict'
 
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const pkg = require('q/package')
 
 describe('probes/q ' + pkg.version, function () {
   before(function () {
-    ao.g.testing(__filename)
+    apm.g.testing(__filename)
   })
   require('./promises')(require('q'))
 })

--- a/test/probes/raw-body.test.js
+++ b/test/probes/raw-body.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const semver = require('semver')
 
@@ -21,13 +21,13 @@ describe('probes.raw-body ' + pkg.version, function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.probes.fs.enabled = false
-    ao.g.testing(__filename)
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.probes.fs.enabled = false
+    apm.g.testing(__filename)
   })
   after(function (done) {
-    ao.probes.fs.enabled = true
+    apm.probes.fs.enabled = true
     emitter.close(done)
   })
 
@@ -54,7 +54,7 @@ describe('probes.raw-body ' + pkg.version, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/redis.test.js
+++ b/test/probes/redis.test.js
@@ -3,10 +3,10 @@
 
 const helper = require('../helper')
 const Address = helper.Address
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const noop = helper.noop
-const addon = ao.addon
+const addon = apm.addon
 
 const redis = require('redis')
 const pkg = require('redis/package')
@@ -26,10 +26,10 @@ describe('probes.redis ' + pkg.version, function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
 
-    ao.g.testing(__filename)
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
@@ -49,7 +49,7 @@ describe('probes.redis ' + pkg.version, function () {
 
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', noop)
+      apm.instrument('fake', noop)
       done()
     }, [
       function (msg) {

--- a/test/probes/restify.test.js
+++ b/test/probes/restify.test.js
@@ -3,7 +3,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 const semver = require('semver')
 
 const expect = require('chai').expect
@@ -25,35 +25,35 @@ describe(`probes.restify ${pkg.version}`, function () {
   let emitter
   let fsState
   let previousTraces
-  const previousHttpClient = ao.probes['http-client'].enabled
+  const previousHttpClient = apm.probes['http-client'].enabled
 
   //
   // Intercept messages for analysis
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
     // restify newer versions of restify use negotiator which does file io
-    fsState = ao.probes.fs.enabled
-    ao.probes.fs.enabled = false
-    previousTraces = ao.probes.restify.collectBacktraces
-    ao.probes.restify.collectBacktraces = false
-    ao.probes['http-client'].enabled = false
-    ao.g.testing(__filename)
+    fsState = apm.probes.fs.enabled
+    apm.probes.fs.enabled = false
+    previousTraces = apm.probes.restify.collectBacktraces
+    apm.probes.restify.collectBacktraces = false
+    apm.probes['http-client'].enabled = false
+    apm.g.testing(__filename)
   })
   after(function (done) {
     emitter.close(done)
     // turn on if desired for testing context
-    if (ao.requestStore.getMetrics) {
+    if (apm.requestStore.getMetrics) {
       process.on('exit', function () {
-        ao.requestStore._hook.disable()
-        interpretMetrics(ao.requestStore.getMetrics())
+        apm.requestStore._hook.disable()
+        interpretMetrics(apm.requestStore.getMetrics())
       })
     }
-    ao.probes.fs.enabled = fsState
-    ao.probes.restify.collectBacktraces = previousTraces
-    ao.probes['http-client'].enabled = previousHttpClient
+    apm.probes.fs.enabled = fsState
+    apm.probes.restify.collectBacktraces = previousTraces
+    apm.probes['http-client'].enabled = previousHttpClient
   })
 
   const check = {
@@ -77,7 +77,7 @@ describe(`probes.restify ${pkg.version}`, function () {
   // send failure.
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {

--- a/test/probes/tedious.test.js
+++ b/test/probes/tedious.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common')
+const { apm } = require('../1.test-common')
 
 const tedious = require('tedious')
 const pkg = require('tedious/package.json')
@@ -21,7 +21,7 @@ describe(`probes.tedious ${pkg.version}`, function () {
   let emitter
 
   beforeEach(function (done) {
-    ao.probes.tedious.enabled = true
+    apm.probes.tedious.enabled = true
     setTimeout(function () {
       done()
     }, 250)
@@ -32,11 +32,11 @@ describe(`probes.tedious ${pkg.version}`, function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
-    ao.g.testing(__filename)
-    ao.probes.fs.enabled = false
-    ao.probes.dns.enabled = false
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
+    apm.g.testing(__filename)
+    apm.probes.fs.enabled = false
+    apm.probes.dns.enabled = false
   })
   after(function (done) {
     emitter.close(done)
@@ -44,7 +44,7 @@ describe(`probes.tedious ${pkg.version}`, function () {
 
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () { })
+      apm.instrument('fake', function () { })
       done()
     }, [
       function (msg) {
@@ -55,12 +55,12 @@ describe(`probes.tedious ${pkg.version}`, function () {
   })
 
   it('should be configured to sanitize SQL by default', function () {
-    ao.probes.tedious.should.have.property('sanitizeSql', true)
-    ao.probes.tedious.sanitizeSql = false
+    apm.probes.tedious.should.have.property('sanitizeSql', true)
+    apm.probes.tedious.sanitizeSql = false
   })
 
   it('should be configured to not tag SQL by default', function () {
-    ao.probes.tedious.should.have.property('tagSql', false)
+    apm.probes.tedious.should.have.property('tagSql', false)
   })
 
   const checks = {
@@ -150,7 +150,7 @@ describe(`probes.tedious ${pkg.version}`, function () {
 
   function test_sanitization (done) {
     helper.test(emitter, function (done) {
-      ao.probes.tedious.sanitizeSql = true
+      apm.probes.tedious.sanitizeSql = true
       query(function () {
         const request = new tedious.Request('select 42, @msg', onComplete)
         request.addParameter('msg', tedious.TYPES.VarChar, 'hello world')
@@ -171,7 +171,7 @@ describe(`probes.tedious ${pkg.version}`, function () {
         checks['mssql-exit'](msg)
       }
     ], function (err) {
-      ao.probes.tedious.sanitizeSql = false
+      apm.probes.tedious.sanitizeSql = false
       done(err)
     })
   }
@@ -203,13 +203,13 @@ describe(`probes.tedious ${pkg.version}`, function () {
         checks['mssql-exit'](msg)
       }
     ], function (err) {
-      ao.probes.tedious.sanitizeSql = false
+      apm.probes.tedious.sanitizeSql = false
       done(err)
     })
   }
 
   function test_tag (done) {
-    ao.probes.tedious.tagSql = true
+    apm.probes.tedious.tagSql = true
     helper.test(emitter, function (done) {
       query(function () {
         return new tedious.Request("select 42, 'hello world'", onComplete)
@@ -227,13 +227,13 @@ describe(`probes.tedious ${pkg.version}`, function () {
         checks['mssql-exit'](msg)
       }
     ], function (err) {
-      ao.probes.tedious.tagSql = false
+      apm.probes.tedious.tagSql = false
       done(err)
     })
   }
 
   function test_disabled (done) {
-    ao.probes.tedious.enabled = false
+    apm.probes.tedious.enabled = false
 
     helper.test(emitter, function (done) {
       query(function () {

--- a/test/probes/zlib.test.js
+++ b/test/probes/zlib.test.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const helper = require('../helper')
-const { ao } = require('../1.test-common.js')
+const { apm } = require('../1.test-common.js')
 const noop = helper.noop
 const once = require('../../lib/utility').once
 
@@ -44,8 +44,8 @@ describe('probes.zlib once', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
   })
   after(function (done) {
     emitter.close(done)
@@ -54,7 +54,7 @@ describe('probes.zlib once', function () {
   // fake test to work around UDP dropped message issue
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', noop)
+      apm.instrument('fake', noop)
       done()
     }, [
       function (msg) {
@@ -74,8 +74,8 @@ describe('probes.zlib', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = ao.addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
   })
   after(function (done) {
     emitter.close(done)

--- a/test/span.test.js
+++ b/test/span.test.js
@@ -10,10 +10,10 @@ const should = require('should')
 const expect = require('chai').expect
 const util = require('util')
 
-const ao = require('..')
-const addon = ao.addon
-const Span = ao.Span
-const Event = ao.Event
+const apm = require('..')
+const addon = apm.addon
+const Span = apm.Span
+const Event = apm.Event
 
 const makeSettings = helper.makeSettings
 
@@ -26,11 +26,11 @@ describe('span', function () {
   //
   before(function (done) {
     emitter = helper.backend(done)
-    ao.sampleRate = addon.MAX_SAMPLE_RATE
-    ao.traceMode = 'always'
+    apm.sampleRate = addon.MAX_SAMPLE_RATE
+    apm.traceMode = 'always'
     // don't count from any previous tests.
-    ao._stats.span.totalCreated = 0
-    ao._stats.span.topSpansCreated = 0
+    apm._stats.span.totalCreated = 0
+    apm._stats.span.topSpansCreated = 0
   })
   after(function (done) {
     emitter.close(done)
@@ -48,7 +48,7 @@ describe('span', function () {
   //
   it('UDP might lose a message', function (done) {
     helper.test(emitter, function (done) {
-      ao.instrument('fake', function () {})
+      apm.instrument('fake', function () {})
       done()
     }, [
       function (msg) {
@@ -180,7 +180,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan('outer', makeSettings(), outerData)
 
     outer.run(function () {
-      inner = ao.lastSpan.descend('inner', innerData)
+      inner = apm.lastSpan.descend('inner', innerData)
       inner.run(function () {})
     })
   })
@@ -224,7 +224,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan('outer', makeSettings(), outerData)
 
     outer.run(function () {
-      inner = ao.lastSpan.descend('inner', innerData)
+      inner = apm.lastSpan.descend('inner', innerData)
       inner.run(function (wrap) {
         const delayed = wrap(function (err, res) {
           expect(err).not.exist
@@ -275,7 +275,7 @@ describe('span', function () {
         expect(res).exist
         expect(res).equal('foo')
 
-        inner = ao.lastSpan.descend('inner', innerData)
+        inner = apm.lastSpan.descend('inner', innerData)
         inner.run(function () {})
       })
 
@@ -310,7 +310,7 @@ describe('span', function () {
     const originalSendReport = Event.prototype.sendReport
     Event.prototype.sendReport = function testSendReport (...args) {
       if (!this.ignore) {
-        ao.lastEvent = this
+        apm.lastEvent = this
       }
       if (counter >= sequencing.length) {
         errors.push(util.format({ found: this, expected: 'nothing' }))
@@ -367,7 +367,7 @@ describe('span', function () {
     const getResults = setupMockEventSending(sequencing, { verbose: false })
 
     outer.run(function () {
-      inner = ao.lastSpan.descend('inner')
+      inner = apm.lastSpan.descend('inner')
       inner.run(function () {})
     })
 
@@ -403,7 +403,7 @@ describe('span', function () {
 
       // our async span invokes a synchronous span
       process.nextTick(function () {
-        const inner = ao.lastSpan.descend('inner')
+        const inner = apm.lastSpan.descend('inner')
         inner.run(() => {})
         cb(null, 'foo')
       })
@@ -430,7 +430,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan(name, settings)
 
     outer.run(function () {
-      inner = ao.lastSpan.descend('inner')
+      inner = apm.lastSpan.descend('inner')
       inner.run(function () {})
     })
 
@@ -459,7 +459,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan(name, settings)
 
     outer.run(function () {
-      inner = ao.lastSpan.descend('inner')
+      inner = apm.lastSpan.descend('inner')
       inner.run(function (wrap) {
         const delayed = wrap(function (err, res) {
           expect(err).not.exist
@@ -501,7 +501,7 @@ describe('span', function () {
         expect(err).not.exist
         expect(res).equal('foo')
 
-        inner = ao.lastSpan.descend('inner')
+        inner = apm.lastSpan.descend('inner')
         inner.run(function () {})
 
         const { sendReportCalls, sendCalls, errors } = getResults()
@@ -544,7 +544,7 @@ describe('span', function () {
       if (depth > maxDepth) {
         return
       }
-      const span = ao.lastSpan.descend(`inner-${depth}`)
+      const span = apm.lastSpan.descend(`inner-${depth}`)
       span.run(digDeeper)
     }
 
@@ -597,7 +597,7 @@ describe('span', function () {
           return
         }
 
-        const span = ao.lastSpan.descend(`inner-${depth}`)
+        const span = apm.lastSpan.descend(`inner-${depth}`)
         span.run(asyncDigDeeper)
       })
 
@@ -659,7 +659,7 @@ describe('span', function () {
 
       // if more depth allowed descend another level.
       if (depth <= maxDepth) {
-        const span = ao.lastSpan.descend(`inner-${depth}`)
+        const span = apm.lastSpan.descend(`inner-${depth}`)
         alternatingRunner(span)
       }
 
@@ -692,7 +692,7 @@ describe('span', function () {
           return
         }
 
-        const span = ao.lastSpan.descend(`inner-${depth}`)
+        const span = apm.lastSpan.descend(`inner-${depth}`)
         alternatingRunner(span)
       })
 
@@ -705,7 +705,7 @@ describe('span', function () {
     const outer = Span.makeEntrySpan(name, settings)
 
     outer.run(function (wrapper) {
-      const span = ao.lastSpan.descend(`inner-${depth}`)
+      const span = apm.lastSpan.descend(`inner-${depth}`)
       span.run(asyncDigDeeper)
       const outerAsyncWrapped = wrapper(function (err, res) {
         expect(err).not.exist
@@ -982,10 +982,10 @@ describe('span', function () {
       sub.run(function (wrap) {
         const cb = wrap(function () {})
         setImmediate(function () {
-          ao.reportInfo(after)
+          apm.reportInfo(after)
           cb()
         })
-        ao.reportInfo(before)
+        apm.reportInfo(before)
       })
       span.info(after)
     })
@@ -1048,16 +1048,16 @@ describe('span', function () {
 
     helper.doChecks(emitter, checks, done)
 
-    ao.requestStore.run(function () {
+    apm.requestStore.run(function () {
       span.enter()
       const sub1 = span.descend('inner-1')
       sub1.run(function () { // inner 1 entry
-        ao.reportInfo(before) // info
+        apm.reportInfo(before) // info
 
         const sub2 = span.descend('inner-3')
         sub2.run(function (wrap) { // inner 3 entry
           timeout(wrap(function () {
-            ao.reportError(error) // deferred error
+            apm.reportError(error) // deferred error
 
             const sub2 = span.descend('inner-4')
             sub2.run(function (wrap) { // inner 4 entry
@@ -1066,7 +1066,7 @@ describe('span', function () {
           }))
         })
 
-        ao.reportInfo(after)
+        apm.reportInfo(after)
       })
 
       const sub2 = span.descend('inner-2')
@@ -1079,7 +1079,7 @@ describe('span', function () {
   })
 
   it('should generate the expected stats', function () {
-    const stats = ao._stats.span
+    const stats = apm._stats.span
     expect(stats.topSpansActive).equal(0, 'no topSpans should be active')
     expect(stats.otherSpansActive).equal(0, 'no spans should be active')
     expect(stats.totalCreated).equal(46, 'total spans created should be correct')

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -5,12 +5,12 @@ const token = process.env.SW_APM_TEST_SERVICE_KEY.split(':')[0]
 const name = 'swoken-Modification-test'
 process.env.SW_APM_SERVICE_KEY = `${token}:${name}`
 
-const ao = require('..')
+const apm = require('..')
 const assert = require('assert')
 
 describe('verify that a swoken is handled correctly', function () {
   it('the service name should be lower case', function () {
-    assert.strictEqual(ao.cfg.serviceKey, `${token}:${name.toLowerCase()}`)
+    assert.strictEqual(apm.cfg.serviceKey, `${token}:${name.toLowerCase()}`)
   })
 
   it('shouldn\'t change the environment variable', function () {


### PR DESCRIPTION
## Overview

This pull request changes API object name used in code and tests from `ao` to `apm` and the string used to create the global Symbol from `SolarWinds.Apm.Once` to the more user friendly `solarwinds-apm`.

## Status

Throughout the code the "agent" is referred to as `ao`. This "leaks" out to customer facing docs in the api reference: https://github.com/solarwindscloud/solarwinds-apm-node/blob/solarwinds-apm/docs/api.md which are automatically generated from code.

## Change

A Search-and-Replace from `ao` to `apm` was done on code.
A Search-and-Replace from `SolarWinds.Apm.Once` to `solarwinds-apm` was done on code.

All tests pass. Integration tests ok.
