### PR TITLE
NH-14617-SQL-Sanitizer-Ability-to-Remove-Double-Quoted-Literals

### DIFF
--- a/docs/probe-defaults.md
+++ b/docs/probe-defaults.md
@@ -64,6 +64,7 @@
 | `enabled` | *boolean* | `true` |
 | `collectBacktraces` | *boolean* | `true` |
 | `sanitizeSql` | *boolean* | `true` |
+| `sanitizerDropDoubleQuotes` | *boolean* | `false` |
 | `tagSql` | *boolean* | `false` |
 
 ## co-render
@@ -144,6 +145,7 @@
 | `enabled` | *boolean* | `true` |
 | `collectBacktraces` | *boolean* | `true` |
 | `sanitizeSql` | *boolean* | `true` |
+| `sanitizerDropDoubleQuotes` | *boolean* | `false` |
 | `tagSql` | *boolean* | `false` |
 
 ## oracledb
@@ -152,6 +154,7 @@
 | `enabled` | *boolean* | `true` |
 | `collectBacktraces` | *boolean* | `true` |
 | `sanitizeSql` | *boolean* | `true` |
+| `sanitizerDropDoubleQuotes` | *boolean* | `false` |
 | `tagSql` | *boolean* | `false` |
 
 ## pg
@@ -160,6 +163,7 @@
 | `enabled` | *boolean* | `true` |
 | `collectBacktraces` | *boolean* | `true` |
 | `sanitizeSql` | *boolean* | `true` |
+| `sanitizerDropDoubleQuotes` | *boolean* | `false` |
 | `tagSql` | *boolean* | `false` |
 
 ## raw-body
@@ -186,6 +190,7 @@
 | `enabled` | *boolean* | `true` |
 | `collectBacktraces` | *boolean* | `true` |
 | `sanitizeSql` | *boolean* | `true` |
+| `sanitizerDropDoubleQuotes` | *boolean* | `false` |
 | `tagSql` | *boolean* | `false` |
 
 ## @hapi/vision

--- a/lib/probe-defaults.js
+++ b/lib/probe-defaults.js
@@ -79,6 +79,7 @@ module.exports = {
     enabled: true,
     collectBacktraces: true,
     sanitizeSql: true,
+    sanitizerDropDoubleQuotes: false,
     tagSql: false
   },
 
@@ -159,6 +160,7 @@ module.exports = {
     enabled: true,
     collectBacktraces: true,
     sanitizeSql: true,
+    sanitizerDropDoubleQuotes: false,
     tagSql: false
   },
 
@@ -167,6 +169,7 @@ module.exports = {
     enabled: true,
     collectBacktraces: true,
     sanitizeSql: true,
+    sanitizerDropDoubleQuotes: false,
     tagSql: false
   },
 
@@ -175,6 +178,7 @@ module.exports = {
     enabled: true,
     collectBacktraces: true,
     sanitizeSql: true,
+    sanitizerDropDoubleQuotes: false,
     tagSql: false
   },
 
@@ -201,6 +205,7 @@ module.exports = {
     enabled: true,
     collectBacktraces: true,
     sanitizeSql: true,
+    sanitizerDropDoubleQuotes: false,
     tagSql: false
   },
 

--- a/lib/probes/cassandra-driver.js
+++ b/lib/probes/cassandra-driver.js
@@ -203,7 +203,7 @@ function patchClientExecute (client, consistencies) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? sqlSanitizer.sanitize(queryStatment)
+          ? sqlSanitizer.sanitize(queryStatment, conf.sanitizerDropDoubleQuotes)
           : queryStatment
 
         // only set queryArgs when not sanitizing
@@ -278,7 +278,7 @@ function patchClientInnerExecute (client, consistencies) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? sqlSanitizer.sanitize(queryStatment)
+          ? sqlSanitizer.sanitize(queryStatment, conf.sanitizerDropDoubleQuotes)
           : queryStatment
 
         // only set queryArgs when not sanitizing
@@ -418,6 +418,6 @@ function mapProp (prop) {
 
 function maybeSanitizeList (queries) {
   return conf.sanitizeSql
-    ? queries.map(query => sqlSanitizer.sanitize(query))
+    ? queries.map(query => sqlSanitizer.sanitize(query, conf.sanitizerDropDoubleQuotes))
     : queries
 }

--- a/lib/probes/mysql.js
+++ b/lib/probes/mysql.js
@@ -125,7 +125,7 @@ function patchClient (proto, Query) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? sqlSanitizer.sanitize(queryStatment)
+          ? sqlSanitizer.sanitize(queryStatment, conf.sanitizerDropDoubleQuotes)
           : queryStatment
 
         // only set queryArgs when not sanitizing

--- a/lib/probes/oracledb.js
+++ b/lib/probes/oracledb.js
@@ -3,7 +3,7 @@
 const shimmer = require('shimmer')
 const ao = require('..')
 const sqlTraceContext = require('../sql-trace-context')
-const sanitizer = require('../sql-sanitizer')
+const sqlSanitizer = require('../sql-sanitizer')
 
 const conf = ao.probes.oracledb
 const logMissing = ao.makeLogMissing('oracledb')
@@ -162,7 +162,7 @@ function patchMethod (conn, method, oracledb, options) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? sanitizer.sanitize(maybeQuery(method, queryStatment))
+          ? sqlSanitizer.sanitize(maybeQuery(method, queryStatment, conf.sanitizerDropDoubleQuotes))
           : queryStatment
 
         // only set queryArgs when not sanitizing

--- a/lib/probes/pg.js
+++ b/lib/probes/pg.js
@@ -124,7 +124,7 @@ function patchClientQuery (client) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? sqlSanitizer.sanitize(queryStatment)
+          ? sqlSanitizer.sanitize(queryStatment, conf.sanitizerDropDoubleQuotes)
           : queryStatment
 
         // only set queryArgs when not sanitizing, trimming large values

--- a/lib/probes/tedious.js
+++ b/lib/probes/tedious.js
@@ -84,7 +84,7 @@ function patchMakeRequest (connection) {
 
         // sanitize, if necessary
         kvpairs.Query = conf.sanitizeSql
-          ? sqlSanitizer.sanitize(queryStatment)
+          ? sqlSanitizer.sanitize(queryStatment, conf.sanitizerDropDoubleQuotes)
           : queryStatment
 
         // only set queryArgs when not sanitizing

--- a/lib/sql-sanitizer.js
+++ b/lib/sql-sanitizer.js
@@ -2,8 +2,8 @@
 
 /* exportable */
 
-const sanitize = (sql) => {
-  return sql
+const sanitize = (sql, dropdoublequotes = false) => {
+  let clean = sql
   // sanitize single quoted strings
 
     // match any use of apostrophe inside a single quoted string
@@ -21,6 +21,18 @@ const sanitize = (sql) => {
     // match digits attached to space, comma, equal or open parentheses or dot
     // will not touch digits attached to alphanumeric chars
     .replace(/[ ,=(.]\d+/ig, (match) => match[0] + '?')
+
+  // double quotes option
+
+  if (dropdoublequotes) {
+    clean = clean
+      // match any double quoted string
+      .replace(/"[^"]*"/ig, '?')
+      // aggressively cleanup of quote used in a double quoted quoted SQL values
+      .replace(/\?(.*?)"/ig, '?')
+  }
+
+  return clean
 }
 
 module.exports = {

--- a/lib/sql-sanitizer.js
+++ b/lib/sql-sanitizer.js
@@ -28,7 +28,7 @@ const sanitize = (sql, dropdoublequotes = false) => {
     clean = clean
       // match any double quoted string
       .replace(/"[^"]*"/ig, '?')
-      // aggressively cleanup of quote used in a double quoted quoted SQL values
+      // aggressively cleanup of quote used in a double quoted SQL values
       .replace(/\?(.*?)"/ig, '?')
   }
 

--- a/test/sql-sanitizer.test.js
+++ b/test/sql-sanitizer.test.js
@@ -274,7 +274,7 @@ describe('sqlSanitizer aggressive cleanup when \' involved', function () {
   })
 })
 
-describe('sqlSanitizer drop double quotes when option is true', function () {
+describe('sqlSanitizer sanitize double quotes when option is true', function () {
   it('should sanitizes a in list', function () {
     const sql = 'SELECT "game_types".* FROM "game_types" WHERE "game_types"."game_id" IN (1162)'
     const result = sqlSanitizer.sanitize(sql, true)
@@ -308,7 +308,7 @@ describe('sqlSanitizer drop double quotes when option is true', function () {
   })
 })
 
-describe('sqlSanitizer not drop double quotes when option is false', function () {
+describe('sqlSanitizer sanitize double quotes when option is false', function () {
   // cases from: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/4593
   // our sanitier is EXPECTED to be overly aggressive
   it('should sanitizes double quoted field names in string (aggressive on SQL92)', function () {


### PR DESCRIPTION
## Overview

This pull request adds the ability to remove Double Quoted values during SQL Sanitization.

## Status

Pull request [264](https://github.com/appoptics/appoptics-apm-node/pull/264) moved SQL sanitization functionality from the Bindings to the Agent replacing an FSM written in C++ ["copied" from PHP agent](https://github.com/librato/oboe/blob/834a1afb4cfafa2c38e7b8f3bbcf35b528c35ab2/contrib/php_oboe/php-oboe/php-8/sql_parser.cc) with a regex based solution [similar to the one used by the Ruby Agent](https://github.com/appoptics/appoptics-apm-ruby/blob/3a96150e6991c0d61b8ca859d62ebb16c9fa587f/lib/rails/generators/solarwinds_apm/templates/solarwinds_apm_initializer.rb#L168).

The original [sanitization spec](https://github.com/librato/trace/blob/master/docs/specs/sql-sanitization.md) called for the option to sanitize double quoted values, however the node agent never provided user configuration options for of the sanitizer and always kept double quoted values.

## Change

* The SQL Sanitizer module was expanded with regex expressions to "sanitize" data out of double quoted strings (assumed to be SQL queries). 

* A probe configuration value `sanitizerDropDoubleQuotes` was added. It is `false` by default. When `sanitizeSql` is `true` and `sanitizerDropDoubleQuotes` is `true`, **both** single quotes and double quotes are sanitized.

* The six probes that use sanitization (cassandra-driver, node-cassandra-cql, mysql, oracledb, pg, tedious) were modified to work with the new config value.

## Discussion

Theoretically there is an alternative way to use and configure the new functionality: user could be given the option to select between the specific sanitization options (none, single, double, both) and configure the functionality by setting selected option as `sanitizeSql` value.

The implemented configuration was chosen for its simplicity (keeping `sanitizeSql` a boolean) while taking into consideration that the new functionality is is a niche feature, with no current user demand.