### PR TITLE
NH-18719-Change-All-Agent-Config-Instructions-to-use-CLI-Require-as-Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,8 @@
 The `solarwinds-apm` module provides [SolarWinds](https://www.solarwinds.com) instrumentation for Node.js.
 
 It supports most commonly used databases, frameworks, and packages automatically. An
-API allows anything to be instrumented.
+API (a.k.a Custom SDK) allows anything to be instrumented. A [SolarWinds](https://www.solarwinds.com) account is required to view traces & metrics.
 
-A [SolarWinds](https://www.solarwinds.com) account is required to view traces & metrics.
-Accounts are [free](https://www.solarwinds.com) for development and testing use. For production usage a [free trial](https://www.solarwinds.com)
-is a great way to start.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Building with node-gyp (via node-pre-gyp) requires:
 - make
 - A proper C/C++ compiler toolchain, like GCC
 
-## Installation
+## Installing
 
 The `solarwinds-apm` module is [available on npm](http://npmjs.org/package/solarwinds-apm) and can be installed
 by navigating to your app root and running:
@@ -38,6 +38,9 @@ by navigating to your app root and running:
 npm install --save solarwinds-apm
 ```
 
+## Authorizing
+
+
 The agent requires a service key, obtained from the SolarWinds dashboard. This is set via the `SW_APM_SERVICE_KEY` environment variable, make
 sure it is available in the environment where your application is running:
 
@@ -45,23 +48,35 @@ sure it is available in the environment where your application is running:
 export SW_APM_SERVICE_KEY="api-token-here:your-service-name"
 ```
 
-Then require `solarwinds-apm` as part of your application start command, or via a `require()` call in the entry point file before any other `require()` calls. 
+A service key is composed of an API token and the name of the service you're installing on. The SolarWinds platform onboarding flow provides the full service key.
+
+
+## Loading
+
+To load the agent into your application you can use one of two methods: require `solarwinds-apm` in your application start command (run time), or require `solarwinds-apm` in your entry point file before any other `require()` calls (build time).
+
 
 Below are simple examples:
 
-**Run Time (preferred)**
-```
+**At Start (preferred)**
+```bash
 node -r solarwinds-apm <app.js>
 ```
 
-**Build Time**
-```
+**In Code**
+```js
+// must be first require
 require('solarwinds-apm')
+
+const express = require('express')
+const app = express()
+app.get('/', (req, res) => res.send('Hello World!'))
+app.listen(3000, () => console.log('Example app listening on port 3000!'))
 ```
 
 Now restart your app and you should see data in your SolarWinds dashboard in a minute or two.
 
-## Important!
+### Important!
 
 `solarwinds-apm` should be the first file required. 
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ The `solarwinds-apm` module provides [SolarWinds](https://www.solarwinds.com) in
 It supports most commonly used databases, frameworks, and packages automatically. An
 API allows anything to be instrumented.
 
-An [SolarWinds](https://www.solarwinds.com) account is required to view metrics.
-Accounts are [free](https://www.solarwinds.com) for development
-and testing use. For production usage a [free trial](https://www.solarwinds.com)
+A [SolarWinds](https://www.solarwinds.com) account is required to view traces & metrics.
+Accounts are [free](https://www.solarwinds.com) for development and testing use. For production usage a [free trial](https://www.solarwinds.com)
 is a great way to start.
 
 ## Dependencies
@@ -16,7 +15,13 @@ This is a **Linux Only package** with no Mac or Windows support. When installed 
 
 It is compatible with Node versions 14, 16 and 18. See [node status](https://github.com/nodejs/Release) for more.
 
-It is dependent on [solarwinds-apm-bindings](https://github.com/solarwindscloud/solarwinds-bindings-node) binary add-on. The SolarWinds APM Agent will first attempt to install a prebuilt binary add-on using [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) and only if that fails, will it attempt to build the add-on from source using [node-gyp](https://github.com/nodejs/node-gyp#on-unix).
+It is dependent on [solarwinds-apm-bindings](https://github.com/solarwindscloud/solarwinds-bindings-node) binary add-on. 
+
+### Binary dependency
+
+The SolarWinds APM Agent will first attempt to install a prebuilt binary add-on using [node-pre-gyp](https://github.com/mapbox/node-pre-gyp). Prebuilt binaries are provided for various versions of Alpine, Centos, Amazon Linux and Red Hat Enterprise Linux.
+
+Only if finding an appropriate prebuilt binary fails, will the agent attempt to build the binary add-on from source using [node-gyp](https://github.com/nodejs/node-gyp#on-unix). In such a case, the target platform suld include the build toolchain.
 
 Building with node-gyp (via node-pre-gyp) requires:
 
@@ -33,20 +38,23 @@ by navigating to your app root and running:
 npm install --save solarwinds-apm
 ```
 
-The agent requires a service key, obtained from the SolarWinds dashboard under "Organization Details",
-to connect to your account.  This is set via the `SW_APM_SERVICE_KEY` environment variable, make
+The agent requires a service key, obtained from the SolarWinds dashboard. This is set via the `SW_APM_SERVICE_KEY` environment variable, make
 sure it is available in the environment where your application is running:
 
 ```
 export SW_APM_SERVICE_KEY="api-token-here:your-service-name"
 ```
 
-Then require `solarwinds-apm` as part of your application start command, or via require() call in your entry point file before any other require() calls. Below are simple examples:
+Then require `solarwinds-apm` as part of your application start command, or via a `require()` call in the entry point file before any other `require()` calls. 
 
+Below are simple examples:
+
+**Run Time (preferred)**
 ```
 node -r solarwinds-apm <app.js>
 ```
 
+**Build Time**
 ```
 require('solarwinds-apm')
 ```
@@ -55,16 +63,12 @@ Now restart your app and you should see data in your SolarWinds dashboard in a m
 
 ## Important!
 
-`solarwinds-apm` should be the first file required. If, for example, you are using the `esm`
-package to enable ES module syntax (import rather than require) and you use the following
-command to invoke your program `node -r esm index.js` then `esm.js` is loaded first and
-`solarwinds-apm` is unable to instrument modules. You can use it, just make sure to require
-`solarwinds-apm` first, e.g., `node -r solarwinds-apm -r esm index.js`.
+`solarwinds-apm` should be the first file required. 
 
-If you are using the custom instrumentation SDK then a reference to the SDK must be obtained, 
-like `const apm = require('solarwinds-apm')`. It you  use the command line option to require
-`solarwinds-apm` (e.g. `node -r solarwinds-apm -r esm index.js`) you can access the SDK using
-`const apm = global[Symbol.for('solarwinds-apm')]`
+If, for example, you are using the `esm` package to enable ES module syntax (import rather than require) and you use the following
+command to invoke your program `node -r esm index.js` then `esm.js` is loaded first and `solarwinds-apm` is unable to instrument modules. You can use it, just make sure to require `solarwinds-apm` first, e.g., `node -r solarwinds-apm -r esm index.js`.
+
+If you are using the custom instrumentation SDK then a reference to the SDK must be obtained,  like `const apm = require('solarwinds-apm')`. It you  use the command line option to require `solarwinds-apm` (e.g. `node -r solarwinds-apm -r esm index.js`) you can access the SDK using `const apm = global[Symbol.for('solarwinds-apm')]`
 
 ## Configuration
 
@@ -77,7 +81,6 @@ To upgrade an existing installation, navigate to your app root and run:
 ```
 npm install --save solarwinds-apm@latest
 ```
-
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Now restart your app and you should see data in your SolarWinds dashboard in a m
 If, for example, you are using the `esm` package to enable ES module syntax (import rather than require) and you use the following
 command to invoke your program `node -r esm index.js` then `esm.js` is loaded first and `solarwinds-apm` is unable to instrument modules. You can use it, just make sure to require `solarwinds-apm` first, e.g., `node -r solarwinds-apm -r esm index.js`.
 
-If you are using the custom instrumentation SDK then a reference to the SDK must be obtained,  like `const apm = require('solarwinds-apm')`. It you  use the command line option to require `solarwinds-apm` (e.g. `node -r solarwinds-apm -r esm index.js`) you can access the SDK using `const apm = global[Symbol.for('solarwinds-apm')]`
+If you are using the custom instrumentation SDK then a reference to the SDK must be obtained,  like `const apm = require('solarwinds-apm')`. If you use the command line option to require `solarwinds-apm` (e.g. `node -r solarwinds-apm -r esm index.js`) you can access the SDK using `const apm = global[Symbol.for('solarwinds-apm')]`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It is dependent on [solarwinds-apm-bindings](https://github.com/solarwindscloud/
 
 The SolarWinds APM Agent will first attempt to install a prebuilt binary add-on using [node-pre-gyp](https://github.com/mapbox/node-pre-gyp). Prebuilt binaries are provided for various versions of Alpine, Centos, Amazon Linux and Red Hat Enterprise Linux.
 
-Only if finding an appropriate prebuilt binary fails, will the agent attempt to build the binary add-on from source using [node-gyp](https://github.com/nodejs/node-gyp#on-unix). In such a case, the target platform suld include the build toolchain.
+Only if finding an appropriate prebuilt binary fails, will the agent attempt to build the binary add-on from source using [node-gyp](https://github.com/nodejs/node-gyp#on-unix). In such a case, the target platform should include the build toolchain.
 
 Building with node-gyp (via node-pre-gyp) requires:
 


### PR DESCRIPTION
## Overview

This pull request is a documentation change attempting to clarify without complxifiing.

Live editing on GitHub is welcomed.

## Status
In order to provide instrumentation, the instrumented app has to require the Node agent prior to all other modules.

In the past (AppOptics UI and all docs) users were instructed to add `require('appoptics-apm')` to the top of their entry point JS file. In SolarWinds APM  the user is encouraged to use runtime include `node -r solarwinds-apm <app.js>` or the alternative method of including at the top of the entry point file.

As long as the instrumented app is “vanilla” JavaScript, those two methods are identical. However, as more and more users use a transpile & build process to create their Node apps, the require (or import) method no longer works since the bundler (a la webpack) is unable to work with the bindings binaries.

While there may be ways to work around it, both at the customer level (using config) and at the agent level (which will require work on the unmaintained `node-pre-gyp`) - just switching to the alternate method should resolve most (or all?) issues. 
