### PR TITLE
NH-19125-Fix-W3C-Trace-Context-Implementation

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -12,7 +12,7 @@ If you were using `appoptics-apm` out-of-the-box with **no** custom instrumentat
 
 There are two main changes to the API:
 
-- Agent now support W3C Trace Context propagation. Due to the implementation chosen, the `startOrContinueTrace` and `getTraceSettings` API functions now expect a `traceparent` and `tracestate` duo rather than a single `xtrace` value. This change will affect any custom instrumentation that uses the above mentioned API functions. The "tracestate" expected is in the format of spanId dash flags (e.g. `77771111aaaa0011-01`) and should either be taken from the `sw` vendor entry in the incoming `tracestate` header or set to `null` if none.
+- Agent now supports W3C Trace Context propagation. Due to the implementation chosen, the `startOrContinueTrace` and `getTraceSettings` API functions now expect a `traceparent` and `tracestate` duo rather than a single `xtrace` value. This change will affect any custom instrumentation that uses the above mentioned API functions. The "tracestate" expected is in the format of spanId dash flags (e.g. `77771111aaaa0011-01`) and should either be taken from the `sw` vendor entry in the incoming `tracestate` header or set to `null` if none.
 
 - Logging API has been simplified and adapted to match W3C Trace Context in logs. There are now two methods: `getTraceObjectForLog` and `getTraceStringForLog` they return either an object or a delimited string containing three values `trace_id`, `span_id` and `trace_flags`.
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -12,7 +12,7 @@ If you were using `appoptics-apm` out-of-the-box with **no** custom instrumentat
 
 There are two main changes to the API:
 
-- Agent now support W3C Trace Context propagation. Due to the implementation chosen, some functions related to trace now expect a traceparent and tracestate duo rather than a single xtrace value. Note that "tracestate" expected is in the format of spanId dash flags. Something like: `77771111aaaa0011-01`
+- Agent now support W3C Trace Context propagation. Due to the implementation chosen, the `startOrContinueTrace` and `getTraceSettings` API functions now expect a `traceparent` and `tracestate` duo rather than a single `xtrace` value. This change will affect any custom instrumentation that uses the above mentioned API functions. The "tracestate" expected is in the format of spanId dash flags (e.g. `77771111aaaa0011-01`) and should either be taken from the `sw` vendor entry in the incoming `tracestate` header or set to `null` if none.
 
 - Logging API has been simplified and adapted to match W3C Trace Context in logs. There are now two methods: `getTraceObjectForLog` and `getTraceStringForLog` they return either an object or a delimited string containing three values `trace_id`, `span_id` and `trace_flags`.
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -12,7 +12,7 @@ If you were using `appoptics-apm` out-of-the-box with **no** custom instrumentat
 
 There are two main changes to the API:
 
-- Agent now support W3C Trace Context propagation. Due to the implementation chosen, some functions related to trace now expect a traceparent and tracestate duo rather than a single xtrace value. Note that "tracestate" expected is in the format of spanId only.
+- Agent now support W3C Trace Context propagation. Due to the implementation chosen, some functions related to trace now expect a traceparent and tracestate duo rather than a single xtrace value. Note that "tracestate" expected is in the format of spanId dash flags. Something like: `77771111aaaa0011-01`
 
 - Logging API has been simplified and adapted to match W3C Trace Context in logs. There are now two methods: `getTraceObjectForLog` and `getTraceStringForLog` they return either an object or a delimited string containing three values `trace_id`, `span_id` and `trace_flags`.
 

--- a/lib/w3c-trace-context.js
+++ b/lib/w3c-trace-context.js
@@ -54,6 +54,13 @@ const extractSpanIdFromTracestate = (tracestate) => {
   return orgPart ? orgPart.slice(3, -3) : ''
 }
 
+const extractLiboboeTracestateFromTracestate = (tracestate) => {
+  const orgPart = extractOrgPartFromTracestate(tracestate)
+
+  return orgPart ? orgPart.slice(3) : ''
+}
+
+
 const tracestatefromTraceparent = (traceparent) => {
   if (!traceparent) return ''
 
@@ -166,7 +173,7 @@ const fromHeaders = (dirty = {}) => {
     traceparent: TfromS(tracestate, traceparent) || traceparent,
     tracestate,
     savedSpanId: extractSpanIdFromTracestate(tracestate),
-    liboboeTracestate: tracestate.split('=')[1]
+    liboboeTracestate: extractLiboboeTracestateFromTracestate(tracestate)
   }
 }
 

--- a/lib/w3c-trace-context.js
+++ b/lib/w3c-trace-context.js
@@ -60,7 +60,6 @@ const extractLiboboeTracestateFromTracestate = (tracestate) => {
   return orgPart ? orgPart.slice(3) : ''
 }
 
-
 const tracestatefromTraceparent = (traceparent) => {
   if (!traceparent) return ''
 

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -385,7 +385,7 @@ describe(`probes.${p}`, function () {
         function (msg) {
           // the edge in "Continuation" is from tracestate.
           expect(msg).property('Edge', otherTracestateOrgPart.slice(3).split('-')[0].toUpperCase())
-          expect(msg).property('sw.tracestate_parent_id')
+          expect(msg).property('sw.tracestate_parent_id', otherTracestateOrgPart.slice(3, -3))
         },
         function (msg) {
           check.server.exit(msg)

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -376,6 +376,42 @@ describe(`probes.${p}`, function () {
       })
     })
 
+    it('should continue "Continuation" tracing when receiving a traceparent and complex tracestate that do not match in header', function (done) {
+      const server = createServer(options, function (req, res) {
+        res.end('done')
+      })
+
+      helper.doChecks(emitter, [
+        function (msg) {
+          // the edge in "Continuation" is from tracestate.
+          expect(msg).property('Edge', otherTracestateOrgPart.slice(3).split('-')[0].toUpperCase())
+          expect(msg).property('sw.tracestate_parent_id')
+        },
+        function (msg) {
+          check.server.exit(msg)
+        }
+      ], function () {
+        server.close()
+      })
+
+      server.listen(function () {
+        const port = server.address().port
+        axios({
+          url: `${p}://localhost:${port}`,
+          headers: {
+            traceparent: baseTraceparent,
+            tracestate: `ot=something-other-people-like,${otherTracestateOrgPart}`
+          }
+        }).then(function (response) {
+          expect(response.headers).property('x-trace')
+          expect(baseTraceparent.slice(0, 35)).equal(response.headers['x-trace'].slice(0, 35))
+          done()
+        }).catch(function (err) {
+          done(err)
+        })
+      })
+    })
+
     //
     // Verify always trace mode forwards sampling data
     //

--- a/test/w3c-trace-context.test.js
+++ b/test/w3c-trace-context.test.js
@@ -607,6 +607,108 @@ describe('w3cTraceContext', function () {
     })
   })
 
+  describe('w3cTraceContext.fromHeaders info liboboeTracestate', function () {
+    it('should be valid when traceparent and tracestate do not match', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: otherTracestateOrgPart
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal('9999888855667788-01')
+    })
+
+    it('should be empty when tracestate is malformed (too long)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: baseTracestateOrgPart.slice(0, 2) + '1' + baseTracestateOrgPart.slice(2)
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (too short)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: baseTracestateOrgPart.slice(0, 6) + baseTracestateOrgPart.slice(7)
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (no dash)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: baseTracestateOrgPart.replace('-', '_')
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when tracestate is malformed (not hex)', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: baseTracestateOrgPart.replace('a', 'z')
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be valid when tracestate is with other vendor and own data', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal(baseTracestateSpanId + '-' + baseTracestateFlags)
+    })
+
+    it('should be first valid when tracestate is malformed and contains own twice', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: baseTracestateOrgPart + ',sw=77771111aaaa0011-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal(baseTracestateSpanId + '-' + baseTracestateFlags)
+    })
+
+    it('should be first when tracestate is with other vendor and own data twice', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,' + baseTracestateOrgPart + ',a2=i_was_before,sw=77771111aaaa0011-01'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal(baseTracestateSpanId + '-' + baseTracestateFlags)
+    })
+
+    it('should be empty when tracestate is with other vendor data only', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,a2=i_was_before'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal('')
+    })
+
+    it('should be empty when there is no tracestate', function () {
+      const myHeaders = {
+        traceparent: baseTraceparent,
+        tracestate: 'a1=continue_from_me,a2=i_was_before'
+      }
+      const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
+
+      expect(id).to.be.equal('')
+    })
+  })
+
   describe('w3cTraceContext.padding', function () {
     it('should have a default value of 00000000', function () {
       expect(w3cTraceContext.padding).to.be.equal('00000000')

--- a/test/w3c-trace-context.test.js
+++ b/test/w3c-trace-context.test.js
@@ -598,8 +598,7 @@ describe('w3cTraceContext', function () {
 
     it('should be empty when there is no tracestate', function () {
       const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,a2=i_was_before'
+        traceparent: baseTraceparent
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).savedSpanId
 
@@ -700,8 +699,7 @@ describe('w3cTraceContext', function () {
 
     it('should be empty when there is no tracestate', function () {
       const myHeaders = {
-        traceparent: baseTraceparent,
-        tracestate: 'a1=continue_from_me,a2=i_was_before'
+        traceparent: baseTraceparent
       }
       const id = w3cTraceContext.fromHeaders(myHeaders).liboboeTracestate
 


### PR DESCRIPTION
## Overview

The pair passed down from agent to bindings and then to oboe is named `traceparent` and `tracestate`, however, what oboe actually is expecting for “tracestate” is not the `tracestate` string received, but rather the value in the key value pair representing our org in the `tracestate` string.

Something like:
`77771111aaaa0011-01`

See: https://github.com/librato/solarwinds-apm-liboboe/blob/165c750abc29a883ec744c5fec1035cbe8522454/liboboe/oboe.h#L237

## Status

Current implementation naively takes the first value from a key value pair in the `tracestate` string and passes it down to oboe.

## Fix

- Our value is extracted from any string and passed down.
- Test cases added.
