### PR TITLE
NH-17913-Clarify-Status-of-traceMode-Config-Settings

### DIFF
--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -64,9 +64,8 @@ function getUnifiedConfig () {
     // developer focused
     traceMode: {
       location: 'c',
-      type: { 0: 0, 1: 1, never: 0, always: 1, disabled: 0, enabled: 1 },
-      default: 1,
-      deprecated: true
+      type: { 0: 0, 1: 1, disabled: 0, enabled: 1 },
+      default: 1
     },
     reporter: { location: 'b', type: ['ssl', 'udp', 'file'] },
     endpoint: { location: 'b', type: 's', name: 'COLLECTOR' },

--- a/test/basics.test.js
+++ b/test/basics.test.js
@@ -24,12 +24,6 @@ if (apm.addon) {
 
 describe('basics', function () {
   it('should set trace mode as string or integer and always get a string', function () {
-    apm.traceMode = 'never'
-    expect(apm.traceMode).equal('disabled')
-
-    apm.traceMode = 'always'
-    expect(apm.traceMode).equal('enabled')
-
     apm.traceMode = 0
     expect(apm.traceMode).equal('disabled')
 
@@ -101,7 +95,7 @@ describe('basics', function () {
   it('should support sampling using getTraceSettings()', function () {
     const skipSample = apm.skipSample
     apm.skipSample = false
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.sampleRate = MAX_SAMPLE_RATE
     let s = apm.getTraceSettings()
     expect(s).to.not.be.false
@@ -118,7 +112,7 @@ describe('basics', function () {
 
   ifapmb('should not call sampleRate setter from sample function', function () {
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     const skipSample = apm.skipSample
     apm.skipSample = false
 

--- a/test/composite/axios.test.js
+++ b/test/composite/axios.test.js
@@ -20,7 +20,7 @@ describe('composite.axios', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
   })
   after(function (done) {
     emitter.close(done)

--- a/test/custom.test.js
+++ b/test/custom.test.js
@@ -109,7 +109,7 @@ describe('custom', function () {
   //
   beforeEach(function (done) {
     apm.sampleRate = apmb.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     emitter = helper.backend(done)
   })
   afterEach(function (done) {

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -40,7 +40,7 @@ describe('error', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
   })
   after(function (done) {
     emitter.close(done)

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -22,7 +22,7 @@ describe('event', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apmb.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
   })
   after(function (done) {
     emitter.close(done)
@@ -82,7 +82,7 @@ describe('event', function () {
     expect(apm.sampling(event.toString())).equal(false)
 
     apm.sampleRate = apmb.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     ev0 = apmb.Event.makeRandom(1)
     event = new Event('test', 'entry', ev0)
 

--- a/test/get-unified-config.test.js
+++ b/test/get-unified-config.test.js
@@ -237,9 +237,12 @@ describe('get-unified-config', function () {
       doChecks(cfg, { global: expected, fatals })
     })
 
-    it('should warn about deprecated config file keys', function () {
+    // there are no deprecated config options as of now.
+    // the functionality is still available.
+    // so keep test example but skip it
+    it.skip('should warn about deprecated config file keys', function () {
       const config = {
-        traceMode: 'always',
+        traceMode: 'always', // this was a deprecated setting but it no longer is.
         sampleRate: 1000000
       }
       writeConfigJSON(config)
@@ -310,9 +313,7 @@ describe('get-unified-config', function () {
 
       const cfg = guc()
 
-      const warnings = [
-        'traceMode is deprecated; it will be invalid in the future'
-      ]
+      const warnings = []
       const overrides = {
         file: `${process.cwd()}/${file}`,
         global: expected,

--- a/test/probes/@hapi/hapi.test.js
+++ b/test/probes/@hapi/hapi.test.js
@@ -35,7 +35,7 @@ describe(`probes.${hapiName} ${pkg.version} ${visionText}`, function () {
     apm.probes.fs.enabled = false
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/@hapi/vision.test.js
+++ b/test/probes/@hapi/vision.test.js
@@ -34,7 +34,7 @@ describe(`probes.${visionName} ${pkg.version} ${hapiText}`, function () {
     apm.probes.fs.enabled = false
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/amqplib.test.js
+++ b/test/probes/amqplib.test.js
@@ -48,7 +48,7 @@ describe('probes.amqplib ' + pkg.version, function () {
   //
   before(function (done) {
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
     emitter = helper.backend(done)
   })

--- a/test/probes/bunyan.test.js
+++ b/test/probes/bunyan.test.js
@@ -181,7 +181,7 @@ describe(`bunyan v${version}`, function () {
   beforeEach(function (done) {
     // make sure we get sampled traces
     apm.sampleRate = apmb.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     // default to the simple 'true'
     apm.cfg.insertTraceIdsIntoLogs = true
     apm.probes.fs.enabled = false

--- a/test/probes/cassandra-driver.test.js
+++ b/test/probes/cassandra-driver.test.js
@@ -62,7 +62,7 @@ describe('probes.cassandra-driver ' + pkg.version, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/co-render.test.js
+++ b/test/probes/co-render.test.js
@@ -35,7 +35,7 @@ describe(`probes/co-render ${pkg.version}`, function () {
     apm.probes.fs.enabled = false
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/crypto.test.js
+++ b/test/probes/crypto.test.js
@@ -35,7 +35,7 @@ describe('probes.crypto', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/director.test.js
+++ b/test/probes/director.test.js
@@ -20,7 +20,7 @@ describe('probes.director ' + pkg.version, function () {
     apm.probes.fs.enabled = false
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/dns.test.js
+++ b/test/probes/dns.test.js
@@ -35,7 +35,7 @@ describe('probes.dns', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/express.test.js
+++ b/test/probes/express.test.js
@@ -86,7 +86,7 @@ describe('probes.express ' + pkg.version, function () {
     apm.probes.express.collectBacktraces = false
     apm.probes.fs.enabled = false
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     emitter = helper.backend(done)
     apm.g.testing(__filename)
   })

--- a/test/probes/fs.test.js
+++ b/test/probes/fs.test.js
@@ -76,7 +76,7 @@ describe('probes.fs', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
   })
   after(function (done) {
     emitter.close(done)

--- a/test/probes/http-common.js
+++ b/test/probes/http-common.js
@@ -57,7 +57,7 @@ describe(`probes.${p}`, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/http-trigger-trace.test.js
+++ b/test/probes/http-trigger-trace.test.js
@@ -357,7 +357,7 @@ describe('probes.http trigger-trace', function () {
     // setup to handle messages
     emitter = helper.backend(done)
     apm.sampleRate = addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
 
     // set the testing context for debugging tests.
     apm.g.testing(__filename)

--- a/test/probes/http-websocket-common.js
+++ b/test/probes/http-websocket-common.js
@@ -43,7 +43,7 @@ describe(`probes.${p} websocket`, function () {
 
   before(function (done) {
     apm.sampleRate = addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
     // intercept message for analysis
     emitter = helper.backend(done)

--- a/test/probes/koa-resource-router.test.js
+++ b/test/probes/koa-resource-router.test.js
@@ -26,7 +26,7 @@ describe('probes/koa-resource-router ' + pkg.version, function () {
     apm.probes.fs.enabled = false
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/koa-route.test.js
+++ b/test/probes/koa-route.test.js
@@ -26,7 +26,7 @@ describe('probes/koa-route ' + pkg.version, function () {
     apm.probes.fs.enabled = false
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/koa-router.test.js
+++ b/test/probes/koa-router.test.js
@@ -25,7 +25,7 @@ describe('probes/koa-router ' + pkg.version, function () {
     apm.probes.fs.enabled = false
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
 
     apm.g.testing(__filename)
   })

--- a/test/probes/koa.test.js
+++ b/test/probes/koa.test.js
@@ -30,7 +30,7 @@ describe('probes/koa ' + pkg.version, function () {
     apm.probes.fs.enabled = false
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
   })
   after(function (done) {
     apm.probes.fs.enabled = true

--- a/test/probes/level.test.js
+++ b/test/probes/level.test.js
@@ -30,7 +30,7 @@ describe('probes.level ' + pkg.version, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {

--- a/test/probes/log4js.test.js
+++ b/test/probes/log4js.test.js
@@ -88,7 +88,7 @@ describe(`log4js v${version}`, function () {
   //
   beforeEach(function (done) {
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.cfg.insertTraceIdsIntoLogs = true
     apm.probes.fs.enabled = false
 

--- a/test/probes/memcached.test.js
+++ b/test/probes/memcached.test.js
@@ -21,7 +21,7 @@ describe('probes.memcached ' + pkg.version, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
 
     apm.g.testing(__filename)
   })

--- a/test/probes/mongodb.test.js
+++ b/test/probes/mongodb.test.js
@@ -42,7 +42,7 @@ describe('probes.mongodb UDP', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
   })
   after(function (done) {
@@ -98,7 +98,7 @@ function makeTests (db_host, host, isReplicaSet) {
     apm.probes.fs.enabled = false
     apm.probes.dns.enabled = false
     apm.sampleRate = addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.probes.mongodb.collectBacktraces = false
     emitter = helper.backend(function () {
       done()

--- a/test/probes/mongoose.test.js
+++ b/test/probes/mongoose.test.js
@@ -52,7 +52,7 @@ describe(`probes/mongoose ${pkg.version} using mongodb`, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     // make them more readable
     backtraces = apm.probes.mongodb.collectBacktraces
     apm.probes.mongodb.collectBacktraces = false

--- a/test/probes/morgan.test.js
+++ b/test/probes/morgan.test.js
@@ -150,7 +150,7 @@ describe(`probes.morgan ${version}`, function () {
   beforeEach(function (done) {
     // make sure we get sampled traces
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     // default to the simple 'true'
     apm.cfg.insertTraceIdsIntoLogs = true
 

--- a/test/probes/mysql.test.js
+++ b/test/probes/mysql.test.js
@@ -41,7 +41,7 @@ describe(`probes.mysql ${pkg.version}`, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.probes.fs.enabled = false
   })
   after(function (done) {

--- a/test/probes/oracledb.test.js
+++ b/test/probes/oracledb.test.js
@@ -27,7 +27,7 @@ describe(`probes.oracledb ${pkg.version}`, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
 
     apm.g.testing(__filename)
   })

--- a/test/probes/pg.test.js
+++ b/test/probes/pg.test.js
@@ -59,7 +59,7 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
 
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.probes.fs.enabled = false
     apm.probes.dns.enabled = false
   })

--- a/test/probes/pino.test.js
+++ b/test/probes/pino.test.js
@@ -129,7 +129,7 @@ describe(`pino v${version}`, function () {
   //
   beforeEach(function (done) {
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.cfg.insertTraceIdsIntoLogs = true
     apm.probes.fs.enabled = false
 

--- a/test/probes/raw-body.test.js
+++ b/test/probes/raw-body.test.js
@@ -22,7 +22,7 @@ describe('probes.raw-body ' + pkg.version, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.probes.fs.enabled = false
     apm.g.testing(__filename)
   })

--- a/test/probes/redis.test.js
+++ b/test/probes/redis.test.js
@@ -27,7 +27,7 @@ describe('probes.redis ' + pkg.version, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
 
     apm.g.testing(__filename)
   })

--- a/test/probes/restify.test.js
+++ b/test/probes/restify.test.js
@@ -33,7 +33,7 @@ describe(`probes.restify ${pkg.version}`, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     // restify newer versions of restify use negotiator which does file io
     fsState = apm.probes.fs.enabled
     apm.probes.fs.enabled = false

--- a/test/probes/tedious.test.js
+++ b/test/probes/tedious.test.js
@@ -33,7 +33,7 @@ describe(`probes.tedious ${pkg.version}`, function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.g.testing(__filename)
     apm.probes.fs.enabled = false
     apm.probes.dns.enabled = false

--- a/test/probes/winston.test.js
+++ b/test/probes/winston.test.js
@@ -207,7 +207,7 @@ describe(`winston v${version}`, function () {
   //
   beforeEach(function (done) {
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     apm.cfg.insertTraceIdsIntoLogs = true
 
     emitter = helper.backend(done)

--- a/test/probes/zlib.test.js
+++ b/test/probes/zlib.test.js
@@ -45,7 +45,7 @@ describe('probes.zlib once', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
   })
   after(function (done) {
     emitter.close(done)
@@ -75,7 +75,7 @@ describe('probes.zlib', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = apm.addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
   })
   after(function (done) {
     emitter.close(done)

--- a/test/span.test.js
+++ b/test/span.test.js
@@ -27,7 +27,7 @@ describe('span', function () {
   before(function (done) {
     emitter = helper.backend(done)
     apm.sampleRate = addon.MAX_SAMPLE_RATE
-    apm.traceMode = 'always'
+    apm.traceMode = 'enabled'
     // don't count from any previous tests.
     apm._stats.span.totalCreated = 0
     apm._stats.span.topSpansCreated = 0


### PR DESCRIPTION
## Overview

This pull request removes untrue warning that traceMode config setting is deprecated (it is not) and the traceMode config options that are no longer supported.

## Status

The `traceMode` configuration option is listed as active: https://github.com/solarwindscloud/solarwinds-apm-node/blob/solarwinds-apm/CONFIGURATION.md and is used in code to enable and disable tracing: https://github.com/solarwindscloud/solarwinds-apm-node/blob/solarwinds-apm/lib/index.js#L328

It is also issuing a warning: `solarwinds-apm:warn traceMode is deprecated; it will be invalid in the future +0ms` as coded here: https://github.com/solarwindscloud/solarwinds-apm-node/blob/solarwinds-apm/lib/get-unified-config.js#L69

It seems like the meaning of the config key changed through the years eliminating `always` but it eventually wasn't deprecated

## Change

- Removed the warning that traceMode config setting is deprecated (it is not). 
- Removed the traceMode config options that are no longer supported.