### PR TITLE
NH-15963-Provide-MongoDB-Instrumentation (pin mongodb version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "minimist": "^1.2.6",
     "mkdirp": "^0.5.1",
     "mocha": "^9.1.3",
-    "mongodb": "^4.8.1",
+    "mongodb": "4.8.1",
     "mongoose": "^5.13.9",
     "morgan": "^1.10.0",
     "mysql": "^2.18.1",


### PR DESCRIPTION
## Overview

This pull request pins the version of mongodb driver used for tests to `4.8.1` as, from an instrumentation point of view, `4.9.0` contains breaking changes.


## Status

Version `4.9.0` of `mongodb` package (https://www.npmjs.com/package/mongodb/v/4.9.0) was released yesterday.

Instrumenting with it results in:

```
  solarwinds-apm:patching probes.mongodb "topologies/server.js" not found +128ms
  solarwinds-apm:patching probes.mongodb "Server.prototype" not found +1ms
  solarwinds-apm:patching probes.mongodb "topologies/replset.js" not found +4ms
  solarwinds-apm:patching probes.mongodb "ReplSet.prototype" not found +0ms
  solarwinds-apm:patching probes.mongodb "topologies/mongos.js" not found +4ms
  solarwinds-apm:patching probes.mongodb "Mongos.prototype" not found +0ms
  solarwinds-apm:patching probes.mongodb "Cursor.prototype" not found +0ms
  solarwinds-apm:patching patched mongodb 4.9.0 +0ms
```

tests fail.

Probe, as is, still provides auto instrumentation of MongoDB versions `2.6` to `5`, using the two supported versions of the driver: legacy `3.7.3` and latest up to `4.8.1`. See MongoDB Node.js driver comparability chart.

## Change

Pinned the version of `mongodb` driver used in tests to `4.8.1`.

## Tests

- With pinned version all tests pass: https://github.com/solarwindscloud/solarwinds-apm-node/actions/runs/2891187942
- Integration tests confirmed that `4.9.0` indeed fails to instrument (without affecting instrumented app) while `4.8.1` is working as expected.
