### PR TITLE
NH-17399-SolarWinds-APM-Release (11.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Features
 - Add auto instrumentation of Node's native DNS module.
 - Add auto instrumentation to the promise interface of Node's native fs module.
 - Add auto instrumentation log4js package.
+- Updates and fixes mongodb probe to support db versions 2.6, 3, 4, 5 and both legacy and and latest drivers.
 - Upgrade tedious (MS SQL) probe to support latest.
 - Upgrade pino logging probe to support latest.
 
@@ -19,8 +20,10 @@ Maintenance
 - Refactor the logging probes API simplifying both api methods and configuration settings.
 - Refactor the morgan probe simplifying implementation and improving functionality.
 - Change naming of headers and reported KV pairs for Trigger Trace requests.
+- Change documented API Object Name to apm and global symbol to solarwinds-apm.
 - Update http/s probe KV pairs.
 - Improve SQL Sanitization moving it form Bindings to Agent.
+- Added ability to remove Double Quoted values during SQL Sanitization.
 - Remove array-flatten from dependencies.
 - Remove methods from dependencies.
 - Remove minimist from dependencies.
@@ -48,3 +51,4 @@ Bug fix
 - Fix the q probe to only binds when tracing.
 - Resolve circular dependencies.
 - Always masks the Service Key.
+- Removes untrue warning that traceMode config setting is deprecated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "ws": "^7.2.0"
       },
       "optionalDependencies": {
-        "solarwinds-apm-bindings": "^12.0.0-prerelease.6"
+        "solarwinds-apm-bindings": "^12.0.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -8740,9 +8740,9 @@
       }
     },
     "node_modules/solarwinds-apm-bindings": {
-      "version": "12.0.0-prerelease.6",
-      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-12.0.0-prerelease.6.tgz",
-      "integrity": "sha512-tX4pD74WLeILecy1g6KVSNMu/LtHnjhmuMdxlRJD38YwG8gmQciI0+q2hDBuOsd3+iayTBqra+GJwGI0a4Pogg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-12.0.0.tgz",
+      "integrity": "sha512-GgQlS8boONmu8lCWQpPWyoP5WOK3+y0b5e8Sw+4LMI9u1FuYybsP5z1Sqt+oOnPoZVKdS9YI2onx8cws1yJk1g==",
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -17104,9 +17104,9 @@
       }
     },
     "solarwinds-apm-bindings": {
-      "version": "12.0.0-prerelease.6",
-      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-12.0.0-prerelease.6.tgz",
-      "integrity": "sha512-tX4pD74WLeILecy1g6KVSNMu/LtHnjhmuMdxlRJD38YwG8gmQciI0+q2hDBuOsd3+iayTBqra+GJwGI0a4Pogg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-12.0.0.tgz",
+      "integrity": "sha512-GgQlS8boONmu8lCWQpPWyoP5WOK3+y0b5e8Sw+4LMI9u1FuYybsP5z1Sqt+oOnPoZVKdS9YI2onx8cws1yJk1g==",
       "optional": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solarwinds-apm",
-  "version": "11.0.0-prerelease.5",
+  "version": "11.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solarwinds-apm",
-      "version": "11.0.0-prerelease.5",
+      "version": "11.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ace-context": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,6 @@
     "ws": "^7.2.0"
   },
   "optionalDependencies": {
-    "solarwinds-apm-bindings": "^12.0.0-prerelease.6"
+    "solarwinds-apm-bindings": "^12.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solarwinds-apm",
-  "version": "11.0.0-prerelease.5",
+  "version": "11.0.0",
   "description": "Agent for SolarWinds APM",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
## Overview
This is a pull request for a **release** version bump (major).

## Release Notes

Features
- Add W3C Trace Context functionality using liboboe 10.3.x+ in mode 1.
- Add Trace Context in Logs that match the Open Telemetry Specification.
- Add Trace Context in Queries (SQL/CQL) to allow integration with SolarWinds DPM using Query Tags.
- Add auto instrumentation of Node's native DNS module.
- Add auto instrumentation to the promise interface of Node's native fs module.
- Add auto instrumentation log4js package.
- Updates and fixes mongodb probe to support db versions 2.6, 3, 4, 5 and both legacy and and latest drivers.
- Upgrade tedious (MS SQL) probe to support latest.
- Upgrade pino logging probe to support latest.

Maintenance
- Refactor the logging probes API simplifying both api methods and configuration settings.
- Refactor the morgan probe simplifying implementation and improving functionality.
- Change naming of headers and reported KV pairs for Trigger Trace requests.
- Change documented API Object Name to apm and global symbol to solarwinds-apm.
- Update http/s probe KV pairs.
- Improve SQL Sanitization moving it form Bindings to Agent.
- Added ability to remove Double Quoted values during SQL Sanitization.
- Remove array-flatten from dependencies.
- Remove methods from dependencies.
- Remove minimist from dependencies.
- Remove glob from dependencies.
- Remove cls-hooked from dependencies.
- Replace debug-custom with debug dependency.
- Gracefully Disable Lambda Functionality until issues are resolved and code refactored.
- Remove bin functionality which was outdated and undocumented.
- Remove deprecated environment variables.
- Remove the code used to detect and potentially handle conflicts with newrelic, strong-agent and appdynamics and also removes the ignoreConfilicts config setting.
- Remove disabled notifier "dead code".
- Remove semver Conditionals for Outdated Node-Versions. If it is not a supported version, behavior is expected to be unexpected.
- Remove debug code.
- Remove support for node versions 10 and 12. Supported versions are now 14, 16 and 18.
- Remove support from old versions of hapi and vision packages.
- Remove support for pg package versions under 7.
- Remove support for amqp package. Package has not been updated in 4 years. Not actively tested. Has alternative.

Breaking changes
- SolarWinds APM is not expected to be backwards compatible with AppOptics APM.

Bug fix
- Completely remove support node-cassandra-cql package.
- Fix false warning of main file loaded before agent.
- Fix the q probe to only binds when tracing.
- Resolve circular dependencies.
- Always masks the Service Key.
- Removes untrue warning that traceMode config setting is deprecated.

## Note
Merging this pull request does not trigger the release. The release is triggered manually by starting of a [Release GitHub workflow](https://github.com/solarwindscloud/solarwinds-apm-node/actions/workflows/release.yml). This should be done after all other workflows pass.
