### PR TITLE
Update to latest bindings

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -22,10 +22,11 @@ RUN apt -y install \
             tzdata
 
 # get and install github cli
-# see: https://github.com/cli/cli/issues/1797#issuecomment-696469523
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 \
-    && apt-add-repository https://cli.github.com/packages \
-    && apt -y install gh
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt update \
+    && apt install gh -y
 
 # install nvm
 ENV NVM_DIR /root/.nvm

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
   dev-agent:
     container_name: dev-agent
-    image: dev-agent
     build:
       context: .
       dockerfile: Dockerfile
@@ -57,24 +56,28 @@ services:
 
   # Containers required for testing supported probes
   cassandra:
+    platform: linux/amd64
     container_name: "cassandra"
     image: cassandra:2 
     ports:
       - "9042:9042"
 
   memcached:
+    platform: linux/amd64
     container_name: "memcached"
     image: memcached 
     ports:
       - "11211:11211"
 
   mongo_2_6:
+    platform: linux/amd64
     container_name: "mongo_2_6"
     image: mongo:2.6 
     ports:
       - "27017:27017"
 
   mongo_3:
+    platform: linux/amd64
     container_name: "mongo_3"
     image: mongo:3 
     ports:
@@ -82,6 +85,7 @@ services:
       - "27018:27017"
 
   mongo_4:
+    platform: linux/amd64
     container_name: "mongo_4"
     image: mongo:4 
     ports:
@@ -89,12 +93,14 @@ services:
       - "27019:27017"
 
   mongo_5:
+    platform: linux/amd64
     container_name: "mongo_5"
     image: mongo:5 
     ports:
       # host:container
       - "27020:27017"
   mssql:
+    platform: linux/amd64
     container_name: "mssql"
     image: "mcr.microsoft.com/mssql/server:2017-CU8-ubuntu"
     ports:
@@ -104,6 +110,7 @@ services:
       - SA_PASSWORD=MeetSQL2017requirements!
 
   mysql:
+    platform: linux/amd64
     container_name: "mysql_5_7"
     image: "mysql:5.7.13"
     ports:
@@ -112,12 +119,14 @@ services:
       - MYSQL_ROOT_PASSWORD=admin
 
   oracle:
+    platform: linux/amd64
     container_name: "oracle"
     image: "traceqa/oracle-express" # traceqa is a SolarWinds account
     ports:
       - "1521:1521"
 
   postgres:
+    platform: linux/amd64
     container_name: "postgres"
     image: "postgres"
     ports:
@@ -126,6 +135,7 @@ services:
       - POSTGRES_PASSWORD=xyzzy
 
   rabbitmq:
+    platform: linux/amd64
     container_name: "rabbitmq" 
     image: rabbitmq:3-management 
     ports:
@@ -133,6 +143,7 @@ services:
       - "5671:5671"
 
   redis:
+    platform: linux/amd64
     container_name: "redis"
     image: redis  
     ports:

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -75,6 +75,7 @@ function getUnifiedConfig () {
       type: ['always', 'never', 'preferred'],
       default: 'preferred'
     },
+    metricFormat: { location: 'b', type: 'i' },
     // not currently used by the node agent
     bufferSize: { location: 'o', type: 'i', name: 'BUFSIZE' },
     logFilePath: { location: 'o', type: 's', name: 'LOGNAME' },
@@ -219,6 +220,21 @@ function getUnifiedConfig () {
       delete apmKeys[envVar]
     }
   })
+
+  //
+  // if the metricFormat hasn't been explicitely provided, infer it from the collector endpoint
+  //
+  if (!('metricFormat' in results.global)) {
+    results.global.metricFormat = 0
+    if ('endpoint' in results.global && results.global.endpoint.includes('appoptics.com')) {
+      // if a custom endpoint is provided and is an appoptics collector, only send TransactionResponseTime
+      results.global.metricFormat = 1
+    } else {
+      // if the provided endpoint isn't an appoptics endpoint we assume apm, and send both formats
+      // if the endpoint isn't provided it will default to apm prod, so also send both formats
+      results.global.metricFormat = 0
+    }
+  }
 
   //
   // now validate the serviceKey.

--- a/lib/get-unified-config.js
+++ b/lib/get-unified-config.js
@@ -225,7 +225,6 @@ function getUnifiedConfig () {
   // if the metricFormat hasn't been explicitely provided, infer it from the collector endpoint
   //
   if (!('metricFormat' in results.global)) {
-    results.global.metricFormat = 0
     if ('endpoint' in results.global && results.global.endpoint.includes('appoptics.com')) {
       // if a custom endpoint is provided and is an appoptics collector, only send TransactionResponseTime
       results.global.metricFormat = 1

--- a/lib/index.js
+++ b/lib/index.js
@@ -345,7 +345,6 @@ if (enabled) {
   if (apm.execEnv.type !== 'serverless' || apm.execEnv.id !== 'lambda') {
     delete options.sampleRate
   }
-  options.mode = 1
 
   // replace the serviceKey with our cleansed service key. the agent
   // will be disabled if the service key doesn't at least look valid.

--- a/package.json
+++ b/package.json
@@ -113,6 +113,6 @@
     "ws": "^7.2.0"
   },
   "optionalDependencies": {
-    "solarwinds-apm-bindings": "^12.0.0"
+    "solarwinds-apm-bindings": "^13.0.0-prerelease.1"
   }
 }

--- a/test/get-unified-config.test.js
+++ b/test/get-unified-config.test.js
@@ -18,7 +18,8 @@ const expectedGlobalDefaults = {
   traceMode: 1,
   logLevel: 2,
   runtimeMetrics: true,
-  unifiedLogging: 'preferred'
+  unifiedLogging: 'preferred',
+  metricFormat: 0
 }
 
 const expectedProbeDefaults = require(`${relativeDir}/lib/probe-defaults`)
@@ -442,7 +443,7 @@ describe('get-unified-config', function () {
   describe('environment variable handling', function () {
     it('should correctly handle env vars with explicit names', function () {
       process.env.SW_APM_DEBUG_LEVEL = 4
-      process.env.SW_APM_COLLECTOR = 'collector-stg.appoptics.com'
+      process.env.SW_APM_COLLECTOR = 'apm.collector.st-ssp.solarwinds.com'
       process.env.SW_APM_TRUSTEDPATH = './certs/special.cert'
 
       const cfg = guc()

--- a/test/get-unified-config.test.js
+++ b/test/get-unified-config.test.js
@@ -658,6 +658,45 @@ describe('get-unified-config', function () {
       doChecks(cfg, expected)
     })
   })
+
+  //
+  // metric format
+  //
+  describe('metricFormat', function () {
+    it('should default to 0 when no endpoint is specified', function () {
+      const cfg = guc()
+
+      const expected = { metricFormat: 0 }
+      doChecks(cfg, { global: expected })
+    })
+
+    it('should default to 0 when a non-appoptics endpoint is specified', function () {
+      const endpoint = 'apm.collector.st-ssp.solarwinds.com'
+      process.env.SW_APM_COLLECTOR = endpoint
+      const cfg = guc()
+
+      const expected = { metricFormat: 0, endpoint }
+      doChecks(cfg, { global: expected })
+    })
+
+    it('should default to 1 when an appoptics endpoint is specified', function () {
+      const endpoint = 'collector.appoptics.com'
+      process.env.SW_APM_COLLECTOR = endpoint
+      const cfg = guc()
+
+      const expected = { metricFormat: 1, endpoint }
+      doChecks(cfg, { global: expected })
+    })
+
+    it('should override the default if provided explicitely', function () {
+      process.env.SW_APM_METRIC_FORMAT = '1'
+      const cfg = guc()
+
+      const expected = { metricFormat: 1 }
+      doChecks(cfg, { global: expected })
+    })
+  })
+
   //
   // probes
   //


### PR DESCRIPTION
Adds the new `metricFormat` setting to the configuration and infers its default value from the collector.

This also updates the docker dev environment to properly work on M1 macs and use the latest working gh cli installation method.