### PR TITLE
TypeScript declarations

### DIFF
--- a/lib/addon.d.ts
+++ b/lib/addon.d.ts
@@ -1,0 +1,39 @@
+import { Metric } from '.'
+
+declare namespace bindings {
+
+class Event {
+  constructor(parent: Event, edge: boolean)
+
+  getSampleFlag(): number
+
+  toString(): string
+
+  sendReport(): number
+  sendStatus(): number
+
+  static makeRandom(sample: boolean): Event
+  static makeFromBuffer(buffer: Buffer): Event
+  static makeFromString(s: string): Event | undefined
+}
+
+const MAX_SAMPLE_RATE: number
+const MAX_METADATA_PACK_LEN: number
+const MAX_TASK_ID_LEN: number
+const MAX_OP_ID_LEN: number
+const TRACE_NEVER: 0
+const TRACE_ALWAYS: 1
+
+function oboeInit(): void
+function isReadyToSample(): boolean
+
+namespace Reporter {
+  function sendMetrics(metrics: Metric[]): { errors: Metric[] }
+  function sendHttpSpan(obj: unknown): string | number
+}
+
+const path: string
+const version: string
+
+}
+export = bindings

--- a/lib/api.js
+++ b/lib/api.js
@@ -1345,6 +1345,7 @@ function sendMetrics (metrics, gopts = {}) {
     const m = metrics[i]
 
     const metric = Object.assign({ addHostTag }, m)
+    // TODO(raph): this won't merge tags as Object.assign isn't recursive
     metric.tags = Object.assign({}, globalTags, m.tags)
     merged.push(metric)
   }

--- a/lib/debug-custom.d.ts
+++ b/lib/debug-custom.d.ts
@@ -1,22 +1,82 @@
 import { Debugger } from 'debug'
 
+/**
+ * Logger creation options
+ */
 interface LoggerOptions {
+  /**
+   * Name of the environment variable used for initialisation which defaults to `DEBUG`
+   */
   envName?: string;
+  /**
+   * Log levels enabled by default
+   */
   defaultLevels?: string | string[];
 }
 
+/**
+ * Standard output logger manager based on the `debug` module
+ */
 declare class Logger {
+  /**
+   * @param name - Name of the logger
+   * @param opts - Creation options
+   */
   constructor(name: string, opts?: LoggerOptions)
 
+  /**
+   * Name of the logger
+   */
   name: string
 
+  /**
+   * Get the full list of currently enabled log levels
+   */
   get logLevel(): string
+  /**
+   * Set the full list of currently enabled log levels
+   */
   set logLevel(level: string | string[])
 
+  /**
+   * Adds log levels to the current set
+   *
+   * @param levels - Array or comma separated list of levels to add
+   * @returns Current log levels after addition
+   *
+   * @example Add `warn` and `debug` log levels
+   * ```js
+   * logger.addEnabled('warn,debug')
+   * ```
+   */
   addEnabled(levels: string | string[]): string
+  /**
+   * Removes log levels from the current set
+   *
+   * @param levels - Array or comma separated list of levels to remove
+   * @returns Current log levels after removal
+   * 
+   * @example Add `debug` log level and remove the rest
+   * ```js
+   * const previousLogLevel = logger.logLevel
+   * logger.addEnabled('debug')
+   * logger.removeEnabled(previousLogLevel)
+   * ```
+   */
   removeEnabled(levels: string | string[]): string
+  /**
+   * Checks whether the current set contains a level
+   * 
+   * @param level - Level to check for
+   */
   has(level: string): boolean
 
+  /**
+   * Creates a new `debug` logger
+   * 
+   * @param level - Log level
+   * @param enable - Whether to also enable the created logger
+   */
   make(level: string, enable?: boolean): Debugger
 }
 export = Logger

--- a/lib/debug-custom.d.ts
+++ b/lib/debug-custom.d.ts
@@ -1,0 +1,22 @@
+import { Debugger } from 'debug'
+
+interface LoggerOptions {
+  envName?: string;
+  defaultLevels?: string | string[];
+}
+
+declare class Logger {
+  constructor(name: string, opts?: LoggerOptions)
+
+  name: string
+
+  get logLevel(): string
+  set logLevel(level: string | string[])
+
+  addEnabled(levels: string | string[]): string
+  removeEnabled(levels: string | string[]): string
+  has(level: string): boolean
+
+  make(level: string, enable?: boolean): Debugger
+}
+export = Logger

--- a/lib/event.d.ts
+++ b/lib/event.d.ts
@@ -1,0 +1,26 @@
+import { KVData } from '.'
+
+interface Edge {
+
+}
+
+declare class Event {
+  constructor(span: string, label: string, parent?: Event, edge?: boolean)
+
+  edges: Edge[]
+
+  set error(error: Error | string)
+
+  get taskId(): string
+  get opId(): string
+
+  set(data: KVData): void
+
+  toString(): string
+
+  sendReport(data?: KVData): void
+
+  static get last(): Event | undefined | null
+  static set last(event: Event | undefined | null)
+}
+export = Event

--- a/lib/event.d.ts
+++ b/lib/event.d.ts
@@ -1,26 +1,65 @@
 import { KVData } from '.'
+import bindings from './addon'
 
 interface Edge {
 
 }
 
+/**
+ * A tracing event
+ */
 declare class Event {
-  constructor(span: string, label: string, parent?: Event, edge?: boolean)
+  /**
+   * 
+   * @param span - Name of the event's span
+   * @param label - Event label (usually `entry` or `exit`)
+   * @param parent - Parent native event
+   * @param edge - Whether this event should edge back to its parent
+   */
+  constructor(span: string, label: string, parent?: bindings.Event, edge?: boolean)
 
   edges: Edge[]
 
+  /**
+   * Set an error that occured during the event
+   */
   set error(error: Error | string)
 
+  /**
+   * `taskId` obtained from native event
+   */
   get taskId(): string
+  /**
+   * `opId` obtained from native event string representation
+   */
   get opId(): string
 
+  /**
+   * Sets key-value data on the event
+   * 
+   * @param data - Key-value pairs to set
+   */
   set(data: KVData): void
 
+  /**
+   * Obtains the X-Trace ID of the event
+   */
   toString(): string
 
+  /**
+   * Sends this event to the reporter
+   * 
+   * @param data - Additional key-value pairs to set
+   */
   sendReport(data?: KVData): void
 
+  /**
+   * Get the last event if any
+   */
   static get last(): Event | undefined | null
+  /**
+   * Set the last event
+   */
   static set last(event: Event | undefined | null)
 }
 export = Event

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -33,7 +33,6 @@ const loggers: typeof log.loggers
  * Key-value data which can be used as tags for the collector
  */
 interface KVData {
-  error: Error | string | number | boolean
   [key: string]: Error | string | number | boolean
 }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,20 +1,20 @@
-import Event from './event'
-import Span from './span'
 import bindings from './addon'
 import log from './loggers'
-import { ClientRequest as HTTPRequest, ServerResponse as HTTPResponse } from 'http'
+import { ClientRequest, IncomingMessage, ServerResponse as HTTPResponse } from 'http'
 import { EventEmitter } from 'events'
 import { Namespace } from 'cls-hooked'
-import express from 'express'
-import hapi from '@hapi/hapi'
-import lambda from 'aws-lambda'
+import * as express from 'express'
+import * as hapi from '@hapi/hapi'
+import * as lambda from 'aws-lambda'
+
+type HTTPRequest = ClientRequest | IncomingMessage
 
 declare namespace apm {
 
 /**
  * Version of the `solarwinds-apm` package
  */
-const version: typeof import('../package.json').version
+const version: string
 /**
  * Root directory of the `solarwinds-apm` package
  */
@@ -422,14 +422,17 @@ function setCustomTxNameFunction(probe: '@hapi/hapi', fn: (request: hapi.Request
  * Event class
  */
 const Event: typeof import('./event')
+type Event = import('./event')
 /**
  * Span class
  */
 const Span: typeof import('./span')
+type Span = import('./span')
 /**
  * Metrics class
  */
 const Metrics: typeof import('./metrics')
+type Metrics = import('./metrics')
 
 /**
  * Checks whether liboboe is ready to sample
@@ -834,7 +837,7 @@ interface Metric {
   /**
    * Value of the metric
    */
-  value: number;
+  value?: number;
   /**
    * Optional tags to attach to the metric
    */
@@ -956,6 +959,7 @@ type LambdaHandler<T, E, C> =
   | ((event: E, context: C, callback: lambda.APIGatewayProxyCallback) => T)
   | ((event: E, context: C) => Promise<T>)
   | ((event: E) => Promise<T>)
+  | lambda.APIGatewayProxyHandler
 
 /**
  * Instruments an AWS Lambda handler

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,6 @@
+// This file, and all other *.d.ts files, are manually maintained, not generated. They should be changed any time the public API is.
+// The test/types.test.ts file should also be updated accordingly to ensure the type declarations behave as expected in practice.
+
 import bindings from './addon'
 import log from './loggers'
 import { ClientRequest, IncomingMessage, ServerResponse as HTTPResponse } from 'http'
@@ -579,6 +582,25 @@ function instrumentHttp<T>(
   options: InstrumentOptions,
   res: HTTPResponse,
 ): T
+
+//
+// INSTRUMENTATION FUNCTIONS AND GENERICS
+//
+// The functions declarations for callback-style instrumentation functions
+// make heavy use of generics and all follow the same pattern.
+// This is require to make sure that both the user-provided callback
+// and the library-provided wrapper around it have the same type signature
+// so that the library-provided callback can only be used in places where
+// the user-provided one also can.
+// 
+// `T` represents the return type of the function receiving the library callback.
+// `CT` represents the return type of both callbacks.
+// `CP` represents the parameters type of both callbacks.
+//
+// A `C` generic type could be used instead of AsyncCallback<CT, CP>
+// but isn't to make it clear to users that even though the user and library provided callbacks
+// have the same signature, they are in fact distinct functions.
+//
 
 /**
  * An asynchronous callback

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,368 @@
+import Event from './event'
+import Span from './span'
+import Metrics from './metrics'
+import bindings from './addon'
+import log from './loggers'
+import { ClientRequest as HTTPRequest, ServerResponse as HTTPResponse } from 'http'
+import { EventEmitter } from 'events'
+import { Namespace } from 'cls-hooked'
+import lambda from 'aws-lambda'
+
+declare namespace apm {
+
+const version: typeof import('../package.json').version
+const root: string
+const omitTraceId: symbol
+
+const logger: typeof log.logger
+const loggers: typeof log.loggers
+
+interface KVData {
+    error: Error | string | number | boolean
+    [key: string]: Error | string | number | boolean
+}
+
+let logLevel: string
+function logLevelAdd(levels: string[] | string): string
+function logLevelRemove(levels: string[] | string): string
+
+interface Config {
+  domainPrefix: boolean;
+  insertTraceIdsIntoLogs: boolean;
+
+  enabled: boolean;
+  serviceKey: string;
+  hostnameAlias?: string;
+  ec2MetadataTimeout?: number;
+  triggerTraceEnabled: boolean;
+  runtimeMetrics: boolean;
+  proxy?: string;
+
+  sampleRate?: number;
+
+  logLevel?: number;
+  wrapLambdaHandler?: string;
+  tokenBucketCapacity?: number;
+  tokenBucketRate?: number;
+  transactionName?: string;
+  stdoutClearNonblocking?: number;
+
+  traceMode?: 0 | 1;
+  reporter?: 'ssl' | 'udp' | 'file';
+  endpoint?: string;
+  trustedPath?: string;
+  unifiedLogging?: 'always' | 'never' | 'preferred';
+  bufferSize?: number;
+  logFilePath?: string;
+  traceMetrics?: boolean;
+  histogramPrecision?: number;
+  maxTransactions?: number;
+  flushMaxWaitTime?: number;
+  eventsFlushInterval?: number;
+  eventsFlushBatchSize?: number;
+  oneFilePerEvent?: boolean;
+}
+const cfg: Config
+
+interface ProbeConfig {
+  enabled: boolean;
+  collectBacktraces?: boolean;
+}
+interface FsProbeConfig extends ProbeConfig {
+  registered: boolean;
+  ignoreErrors: { [method: string]: { [error: string]: boolean } };
+}
+interface HttpProbeConfig extends ProbeConfig {
+  includeRemoteUrlParams: boolean;
+}
+interface HttpServerProbeConfig extends HttpProbeConfig {
+  'client-ip-header'?: string;
+}
+interface SqlProbeConfig extends ProbeConfig {
+  sanitizeSql: boolean;
+  sanitizerDropDoubleQuotes: boolean;
+  tagSql: boolean;
+}
+interface MongoProbeConfig extends ProbeConfig {
+  sanitizeObject: boolean;
+}
+interface EnabledProbeConfig {
+  enabled: true;
+}
+interface LoggingProbeConfig {
+  enabled: boolean;
+}
+interface ProbesConfig {
+  crypto: ProbeConfig;
+  dns: ProbeConfig;
+  fs: FsProbeConfig;
+  http: HttpServerProbeConfig;
+  https: HttpServerProbeConfig;
+  'http-client': HttpProbeConfig;
+  'https-client': HttpProbeConfig;
+  zlib: ProbeConfig;
+
+  amqplib: ProbeConfig;
+  'cassandra-driver': SqlProbeConfig;
+  'co-render': ProbeConfig;
+  director: ProbeConfig;
+  express: ProbeConfig;
+  '@hapi/hapi': ProbeConfig;
+  koa: ProbeConfig;
+  'koa-resource-router': ProbeConfig;
+  'koa-route': ProbeConfig;
+  'koa-router': ProbeConfig;
+  levelup: ProbeConfig;
+  memcached: ProbeConfig;
+  mongodb: MongoProbeConfig;
+  mysql: SqlProbeConfig;
+  oracledb: SqlProbeConfig;
+  pg: SqlProbeConfig;
+  'raw-body': ProbeConfig;
+  redis: ProbeConfig;
+  restify: ProbeConfig;
+  tedious: SqlProbeConfig;
+  '@hapi/vision': ProbeConfig;
+
+  'aws-sdk': EnabledProbeConfig;
+  bcrypt: EnabledProbeConfig;
+  bluebird: EnabledProbeConfig;
+  'generic-pool': EnabledProbeConfig;
+  mongoose: EnabledProbeConfig;
+  q: EnabledProbeConfig;
+
+  bunyan: LoggingProbeConfig;
+  log4js: LoggingProbeConfig;
+  morgan: LoggingProbeConfig;
+  pino: LoggingProbeConfig;
+  winston: LoggingProbeConfig;
+}
+const probes: ProbesConfig
+
+interface StringTransactionSetting {
+  type: 'url';
+  string: string;
+}
+interface RegexTransactionSetting {
+  type: 'url';
+  regex: RegExp;
+}
+type TransactionSetting = StringTransactionSetting | RegexTransactionSetting
+const specialUrls: TransactionSetting[]
+
+interface LinuxExecEnv {
+  type: 'linux';
+  id: undefined;
+  nodeEnv: string;
+}
+interface LambdaExecEnv {
+  type: 'serverless';
+  id: 'lambda';
+  nodeEnv: string;
+}
+type ExecEnv = LinuxExecEnv | LambdaExecEnv
+const execEnv: ExecEnv
+
+function getDomainPrefix(req: HTTPRequest): string
+
+function makeLogMissing(name: string): (missing: string) => void
+
+const modeMap: {
+  0: 0;
+  1: 1;
+  never: 0;
+  always: 1;
+  disabled: 0;
+  enabled: 1;
+}
+const modeToStringMap: {
+  0: 'disabled';
+  1: 'enabled';
+}
+
+const cls: typeof import('ace-context') | undefined
+const addon: typeof bindings
+const reporter: typeof bindings.Reporter
+
+let startup: boolean
+
+let traceMode: keyof typeof modeMap
+let sampleRate: number
+
+const tracing: boolean
+const traceId: string
+
+let lastEvent: Event | undefined | null
+let lastSpan: Span | undefined | null
+const maps: Object
+
+const lambda: {} | undefined
+
+const requestStore: Namespace
+function resetRequestStore(options?): void
+function clsCheck(msg?: string): boolean
+
+function stack(text: string, n?: number): string
+function backtrace(): string
+
+function bind<F extends Function>(fn: F): F
+function bindEmitter<E extends EventEmitter>(em: E): E
+
+const wrappedFlag: symbol
+
+const Event: Event
+const Span: Span
+const Metrics: Metrics
+
+function readyToSample(ms: number, obj?: { status?: number }): boolean
+
+interface TraceSettings {
+  doSample: boolean;
+  doMetrics: boolean;
+  traceTaskId: Event;
+  edge?: boolean;
+  source: number;
+  rate: number;
+  mode: number;
+  ttRequested: boolean;
+  ttOptions: string;
+  ttSignature: string;
+  ttTimestamp: number;
+  inboundXtrace?: string;
+}
+interface GetTraceSettingsOptions {
+  typeRequested?: 0 | 1;
+  xtraceOpts?: string;
+  xtraceOptsSig?: string;
+  xtraceOptsTimestamp?: number;
+  customTriggerMode?: 0 | 1;
+}
+function getTraceSettings(traceparent: string, tracestate: string, options?: GetTraceSettingsOptions | number): TraceSettings
+
+function sampling(item: string | Event | bindings.Event): boolean
+
+function traceToEvent(traceparent: string): bindings.Event
+
+function patchResponse(res: HTTPResponse): void
+function addResponseFinalizer(res: HTTPResponse, finalizer: () => void): void
+
+interface SpanInfo {
+  name: string;
+  kvpairs?: Object;
+  finalize?: (span: Span, last: Span) => void;
+}
+type SpanOptions = string | (() => SpanInfo)
+interface InstrumentOptions {
+  enabled?: boolean;
+  collectBacktraces?: boolean;
+}
+
+function instrumentHttp<T>(
+  span: SpanOptions,
+  run: () => T,
+  options: InstrumentOptions,
+  res: HTTPResponse,
+): T
+
+type AsyncCallback<T, P extends unknown[]> = (...args: P) => T
+type AsyncHandler<P extends unknown[]> = AsyncCallback<unknown, P>
+type AsyncWrapper<T = unknown, P extends unknown[] = unknown[]> =
+  (cb: AsyncCallback<T, P>, handler?: AsyncHandler<P>) => AsyncCallback<T, P>
+
+function instrument<T, CT, CP extends unknown[]>(
+  span: SpanOptions,
+  run: (done: AsyncCallback<CT, CP>) => T,
+  options: InstrumentOptions,
+  callback: AsyncCallback<CT, CP>,
+): T
+function instrument<T, CT, CP extends unknown[]>(
+  span: SpanOptions,
+  run: (done: AsyncCallback<CT, CP>) => T,
+  callback: AsyncCallback<CT, CP>,
+): T
+function instrument<T>(
+  span: SpanOptions,
+  run: () => T,
+  options?: InstrumentOptions,
+): T
+
+function pInstrument<T>(
+  span: SpanOptions,
+  run: () => Promise<T>,
+  options?: InstrumentOptions,
+): Promise<T>
+
+interface InstrumentContinueOptions extends InstrumentOptions {
+  forceNewTrace?: boolean
+  customTxName?: string | (() => string)
+}
+
+function startOrContinueTrace<T, CT, CP extends unknown[]>(
+  traceparent: string,
+  tracestate: string,
+  span: SpanOptions,
+  run: (done: AsyncCallback<CT, CP>) => T,
+  options: InstrumentOptions,
+  callback: AsyncCallback<CT, CP>,
+): T
+function startOrContinueTrace<T, CT, CP extends unknown[]>(
+  traceparent: string,
+  tracestate: string,
+  span: SpanOptions,
+  run: (done: AsyncCallback<CT, CP>) => T,
+  callback: AsyncCallback<CT, CP>,
+): T
+function startOrContinueTrace<T>(
+  traceparent: string,
+  tracestate: string,
+  span: SpanOptions,
+  run: () => T,
+  options?: InstrumentContinueOptions,
+): T
+
+function pStartOrContinueTrace<T>(
+  traceparent: string,
+  tracestate: string,
+  span: SpanOptions,
+  run: () => Promise<T>,
+  options?: InstrumentContinueOptions,
+): Promise<T>
+
+function reportInfo(data: KVData): void
+function reportError(error: Error | string): void
+
+interface Metric {
+  name: string;
+  count?: number;
+  value?: number;
+  tags?: KVData;
+  addHostTag?: boolean;
+}
+interface MetricsOptions {
+  tags?: KVData;
+  addHostTag?: boolean;
+}
+
+function sendMetrics(metrics: Metric | Metric[], options?: MetricsOptions): { errors: Metric[] }
+
+interface TraceObjectForLog {
+  trace_id: string;
+  span_id: string;
+  trace_flags: string;
+}
+function getTraceObjectForLog(): TraceObjectForLog | null
+function getTraceStringForLog(): string
+
+type LambdaHandler<T, E, C> =
+  | ((event: E, context: C, callback: lambda.APIGatewayProxyCallback) => T)
+  | ((event: E, context: C) => Promise<T>)
+  | ((event: E) => Promise<T>)
+
+function wrapLambdaHandler<
+  T extends lambda.APIGatewayProxyResult = lambda.APIGatewayProxyResult,
+  E extends lambda.APIGatewayEvent = lambda.APIGatewayEvent,
+  C extends lambda.Context = lambda.Context,
+>(handler: LambdaHandler<T, E, C>): (event: E, context: C) => Promise<T>
+
+}
+export = apm

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,31 +1,86 @@
 import Event from './event'
 import Span from './span'
-import Metrics from './metrics'
 import bindings from './addon'
 import log from './loggers'
 import { ClientRequest as HTTPRequest, ServerResponse as HTTPResponse } from 'http'
 import { EventEmitter } from 'events'
 import { Namespace } from 'cls-hooked'
+import express from 'express'
+import hapi from '@hapi/hapi'
 import lambda from 'aws-lambda'
 
 declare namespace apm {
 
+/**
+ * Version of the `solarwinds-apm` package
+ */
 const version: typeof import('../package.json').version
+/**
+ * Root directory of the `solarwinds-apm` package
+ */
 const root: string
-const omitTraceId: symbol
 
+/**
+ * Global logger manager
+ */
 const logger: typeof log.logger
+/**
+ * Global collection of loggers
+ */
 const loggers: typeof log.loggers
 
+/**
+ * Key-value data which can be used as tags for the collector
+ */
 interface KVData {
-    error: Error | string | number | boolean
-    [key: string]: Error | string | number | boolean
+  error: Error | string | number | boolean
+  [key: string]: Error | string | number | boolean
 }
 
+/**
+ * Comma separated list of log settings
+ * 
+ * @example Set the log settings
+ * ```js
+ * apm.logLevel = 'warn,error'
+ * ```
+ * 
+ * @example Get the log settings
+ * ```js
+ * const settings = apm.logLevel
+ * ```
+ */
 let logLevel: string
+/**
+ * Adds log levels to the current set
+ *
+ * @param levels - Array or comma separated list of levels to add
+ * @returns Current log levels after addition
+ *
+ * @example Add `warn` and `debug` log levels
+ * ```js
+ * apm.logLevelAdd('warn,debug')
+ * ```
+ */
 function logLevelAdd(levels: string[] | string): string
+/**
+ * Removes log levels from the current set
+ *
+ * @param levels - Array or comma separated list of levels to remove
+ * @returns Current log levels after removal
+ * 
+ * @example Add `debug` log level and remove the rest
+ * ```js
+ * const previousLogLevel = apm.logLevel
+ * apm.logLevelAdd('debug')
+ * apm.logLevelRemove(previousLogLevel)
+ * ```
+ */
 function logLevelRemove(levels: string[] | string): string
 
+/**
+ * Package configuration
+ */
 interface Config {
   domainPrefix: boolean;
   insertTraceIdsIntoLogs: boolean;
@@ -47,7 +102,7 @@ interface Config {
   transactionName?: string;
   stdoutClearNonblocking?: number;
 
-  traceMode?: 0 | 1;
+  traceMode?: 0 | 1 | 'never' | 'always' | 'enabled' | 'disabled';
   reporter?: 'ssl' | 'udp' | 'file';
   endpoint?: string;
   trustedPath?: string;
@@ -61,37 +116,85 @@ interface Config {
   eventsFlushInterval?: number;
   eventsFlushBatchSize?: number;
   oneFilePerEvent?: boolean;
+  metricFormat: 0 | 1 | 2;
 }
+/**
+ * Global package configuration
+ */
 const cfg: Config
 
+/**
+ * Configuration for a module instrumentation probe
+ */
 interface ProbeConfig {
+  /**
+   * Whether the probe is enabled
+   */
   enabled: boolean;
+  /**
+   * Whether the probe should collect backtraces
+   */
   collectBacktraces?: boolean;
 }
+/**
+ * Configuration specific to the `fs` instrumentation probe
+ */
 interface FsProbeConfig extends ProbeConfig {
   registered: boolean;
+  /**
+   * Object mapping method names to errors to ignore
+   * 
+   * @example Ignore `ENOENT` for `readFile`
+   * ```js
+   * {
+   *   readfile: {
+   *     'ENOENT': true,
+   *   },
+   * }
+   */
   ignoreErrors: { [method: string]: { [error: string]: boolean } };
 }
+/**
+ * Configuration specific to the `http` and `https` instrumentation probes
+ */
 interface HttpProbeConfig extends ProbeConfig {
   includeRemoteUrlParams: boolean;
 }
+/**
+ * Configuration specific to server methods for the `http` and `https` instrumentation probes
+ */
 interface HttpServerProbeConfig extends HttpProbeConfig {
   'client-ip-header'?: string;
 }
+/**
+ * Configuration specific to SQL instrumentation probes
+ */
 interface SqlProbeConfig extends ProbeConfig {
   sanitizeSql: boolean;
   sanitizerDropDoubleQuotes: boolean;
   tagSql: boolean;
 }
+/**
+ * Configuration specific to MongoDB instrumantation probes
+ */
 interface MongoProbeConfig extends ProbeConfig {
   sanitizeObject: boolean;
 }
+/**
+ * Configuration for instrumentation probes that are always enabled
+ */
 interface EnabledProbeConfig {
   enabled: true;
 }
+/**
+ * Configuration for logging instrumentation probes
+ */
 interface LoggingProbeConfig {
   enabled: boolean;
 }
+/**
+ * Configuration for each specific instrumentation probe
+ */
 interface ProbesConfig {
   crypto: ProbeConfig;
   dns: ProbeConfig;
@@ -150,23 +253,56 @@ interface RegexTransactionSetting {
 type TransactionSetting = StringTransactionSetting | RegexTransactionSetting
 const specialUrls: TransactionSetting[]
 
+/**
+ * Execution environment for Linux hosts
+ */
 interface LinuxExecEnv {
   type: 'linux';
   id: undefined;
+  /**
+   * Value of the `NODE_ENV` environment variable
+   */
   nodeEnv: string;
 }
+/**
+ * Execution environment for AWS Lambda hosts
+ */
 interface LambdaExecEnv {
   type: 'serverless';
   id: 'lambda';
+  /**
+   * Value of the `NODE_ENV` environment variable
+   */
   nodeEnv: string;
 }
+/**
+ * Execution environment
+ */
 type ExecEnv = LinuxExecEnv | LambdaExecEnv
+/**
+ * Current execution environment
+ */
 const execEnv: ExecEnv
 
+/**
+ * Extracts the host from a request
+ * 
+ * @param req - Request to extract the host from
+ * @returns Host and possibly port the request is coming from
+ */
 function getDomainPrefix(req: HTTPRequest): string
 
-function makeLogMissing(name: string): (missing: string) => void
+/**
+ * Creates a logger that consistently formats patching errors
+ * 
+ * @param name - Name of the module being pathced
+ * @returns Function that consistently logs and formats patching errors
+ */
+function makeLogMissing(name: string): (missing: string | Error) => void
 
+/**
+ * Mapping of valid logging modes to native values
+ */
 const modeMap: {
   0: 0;
   1: 1;
@@ -175,58 +311,182 @@ const modeMap: {
   disabled: 0;
   enabled: 1;
 }
+/**
+ * Mapping of native logging mode values to readable names
+ */
 const modeToStringMap: {
   0: 'disabled';
   1: 'enabled';
 }
 
+/**
+ * Asynchronous execution context module
+ */
 const cls: typeof import('ace-context') | undefined
+/**
+ * Bindings module
+ */
 const addon: typeof bindings
+/**
+ * Native reporter
+ */
 const reporter: typeof bindings.Reporter
 
-let startup: boolean
-
+/**
+ * Current trace mode
+ */
 let traceMode: keyof typeof modeMap
+/**
+ * Current sample rate in parts of 1'000'000
+ * 
+ * @example Set a sample rate to 10%
+ * ```js
+ * apm.sampleRate = 100000
+ * ```
+ */
 let sampleRate: number
 
+/**
+ * Whether the current code path is being traced
+ */
 const tracing: boolean
-const traceId: string
+/**
+ * X-Trace ID of the last event if any
+ */
+const traceId: string | undefined
 
+/**
+ * Last event if any
+ */
 let lastEvent: Event | undefined | null
+/**
+ * Last span if any
+ */
 let lastSpan: Span | undefined | null
-const maps: Object
 
-const lambda: {} | undefined
-
+/**
+ * Asynchronous execution context
+ */
 const requestStore: Namespace
+/**
+ * Resets the asynchronous execution context
+ */
 function resetRequestStore(options?): void
+/**
+ * Checks whether the asynchronous context is active and healthy
+ * 
+ * @param msg - Optional message to log
+ */
 function clsCheck(msg?: string): boolean
 
+/**
+ * Generates a track trace
+ * 
+ * @param text - Message to use as the top stack frame
+ * @param n - Depth of the stack trace
+ */
 function stack(text: string, n?: number): string
+/**
+ * Generates a backtrace
+ */
 function backtrace(): string
 
+/**
+ * Binds a function to the asynchronous execution context if tracing
+ * 
+ * @param fn - Function to bind
+ * @returns Bound function if tracing or untouched argument otherwise
+ */
 function bind<F extends Function>(fn: F): F
+/**
+ * Binds a node event emitter to the asynchronous execution tracing if tracing
+ * 
+ * @param em - Event emitter to bind
+ * @returns Bound emitter if tracing or untouched argument otherwise
+ */
 function bindEmitter<E extends EventEmitter>(em: E): E
 
-const wrappedFlag: symbol
+/**
+ * Sets a custom transaction name function for the `express` instrumentation probe
+ * 
+ * @param fn - Function that can either return the custom transaction name or false to use the default
+ */
+function setCustomTxNameFunction(probe: 'express', fn: (req: express.Request, res: express.Response) => string | false): true
+/**
+ * Sets a custom transaction name function for the `@hapi/hapi` instrumentation probe
+ * 
+ * @param fn - Function that can either return the custom transaction name or false to use the default
+ */
+function setCustomTxNameFunction(probe: '@hapi/hapi', fn: (request: hapi.Request) => string | false): true
 
-const Event: Event
-const Span: Span
-const Metrics: Metrics
+/**
+ * Event class
+ */
+const Event: typeof import('./event')
+/**
+ * Span class
+ */
+const Span: typeof import('./span')
+/**
+ * Metrics class
+ */
+const Metrics: typeof import('./metrics')
 
-function readyToSample(ms: number, obj?: { status?: number }): boolean
+/**
+ * Checks whether liboboe is ready to sample
+ * 
+ * @param ms - Optionally wait at most this amount of time in milliseconds before returning
+ * @param obj - When provided its `status` property will be set to the native return status
+ */
+function readyToSample(ms?: number, obj?: { status?: number }): boolean
 
+/**
+ * Trace settings returned by liboboe
+ */
 interface TraceSettings {
+  /**
+   * Whether to sample
+   */
   doSample: boolean;
+  /**
+   * Whether to collect metrics
+   */
   doMetrics: boolean;
-  traceTaskId: Event;
-  edge?: boolean;
+  /**
+   * The parent event
+   */
+  traceTaskId: bindings.Event;
+  /**
+   * Whether to edge back to the parent ID
+   */
+  edge: boolean;
+  /**
+   * Sample decision source
+   */
   source: number;
+  /**
+   * Sample rate used
+   */
   rate: number;
+  /**
+   * Local mode to use
+   */
   mode: number;
+  /**
+   * Whether a trigger trace was requested
+   */
   ttRequested: boolean;
+  /**
+   * X-Trace-Option header value
+   */
   ttOptions: string;
+  /**
+   * X-Trace-Option-Signature header value
+   */
   ttSignature: string;
+  /**
+   * UNIX timestamp value from X-Trace-Options
+   */
   ttTimestamp: number;
   inboundXtrace?: string;
 }
@@ -237,26 +497,80 @@ interface GetTraceSettingsOptions {
   xtraceOptsTimestamp?: number;
   customTriggerMode?: 0 | 1;
 }
+/**
+ * Obtains the trace settings from liboboe
+ */
 function getTraceSettings(traceparent: string, tracestate: string, options?: GetTraceSettingsOptions | number): TraceSettings
 
+/**
+ * Determines whether the sample flag is set
+ * 
+ * @param item - Item to retrieve the sample flag from
+ */
 function sampling(item: string | Event | bindings.Event): boolean
 
-function traceToEvent(traceparent: string): bindings.Event
+/**
+ * Creates a native event from a traceparent
+ * 
+ * @param traceparent - Trace parent ID
+ * @returns Native event or undefined if the trace parent ID is invalid
+ */
+function traceToEvent(traceparent: string): bindings.Event | undefined
 
+/**
+ * Patches an HTTP response
+ */
 function patchResponse(res: HTTPResponse): void
+/**
+ * Adds a finalizer to run when the given response ends
+ * 
+ * @param res - HTTP response object
+ * @param finalizer - Finalizer function called after the response ends
+ */
 function addResponseFinalizer(res: HTTPResponse, finalizer: () => void): void
 
+/**
+ * Span creation info
+ */
 interface SpanInfo {
+  /**
+   * Name of the span
+   */
   name: string;
-  kvpairs?: Object;
+  /**
+   * Key-value pairs of tags to add to the span
+   */
+  kvpairs?: KVData;
+  /**
+   * Optional callback receiving the created span to modify it
+   */
   finalize?: (span: Span, last: Span) => void;
 }
 type SpanOptions = string | (() => SpanInfo)
+/**
+ * Instrumentation options
+ */
 interface InstrumentOptions {
+  /**
+   * Whether to instrument
+   */
   enabled?: boolean;
+  /**
+   * Whether to collect backtraces
+   */
   collectBacktraces?: boolean;
 }
 
+/**
+ * Instruments an HTTP request/response handler
+ * 
+ * @param span - Span name or function returning span creation info
+ * @param run - Code to instrument and run
+ * @param options - Instrumentation options
+ * @param res - HTTP response to patch
+ * 
+ * @returns Return value of the instrumented code
+ */
 function instrumentHttp<T>(
   span: SpanOptions,
   run: () => T,
@@ -264,93 +578,379 @@ function instrumentHttp<T>(
   res: HTTPResponse,
 ): T
 
+/**
+ * An asynchronous callback
+ * 
+ * @typeParam T - Return type of the callpack
+ * @typeParam P - Parameters type of the callback
+ */
 type AsyncCallback<T, P extends unknown[]> = (...args: P) => T
 type AsyncHandler<P extends unknown[]> = AsyncCallback<unknown, P>
 type AsyncWrapper<T = unknown, P extends unknown[] = unknown[]> =
   (cb: AsyncCallback<T, P>, handler?: AsyncHandler<P>) => AsyncCallback<T, P>
 
+/**
+ * Instruments callback-style code
+ * 
+ * @param span - Span name or function returning span creation info
+ * @param run - Callback-style code to instrument and run receiving the instrumented callback as its sole argument
+ * @param options - Instrumentation options
+ * @param callback - Callback to instrument and pass back to the run function
+ * 
+ * @returns Return value of the instrumented code (not of the callback)
+ * 
+ * @example
+ * ```ts
+ * const span = () => ({ name: 'custom', kvpairs: { foo: 'bar' } })
+ * const options = { enabled: true, collectBacktraces: true }
+ * 
+ * function callback(err: ErrnoException | null, data: string | null) {
+ *   if (err) console.error(err)
+ *   else console.log(data)
+ * }
+ * 
+ * apm.instrument(span, (done) => {
+ *   fs.readFile('example.txt', { encoding: 'utf8' }, done)
+ * }, options, callback)
+ * ```
+ */
 function instrument<T, CT, CP extends unknown[]>(
   span: SpanOptions,
   run: (done: AsyncCallback<CT, CP>) => T,
   options: InstrumentOptions,
   callback: AsyncCallback<CT, CP>,
 ): T
+/**
+ * Instruments callback-style code
+ * 
+ * @param span - Span name or function returning span creation info
+ * @param run - Callback-style code to instrument and run receiving the instrumented callback as its sole argument
+ * @param callback - Callback to instrument and pass back to the run function
+ * 
+ * @returns Return value of the instrumented code (not of the callback)
+ * 
+ * @example
+ * ```ts
+ * const span = () => ({ name: 'custom', kvpairs: { foo: 'bar' } })
+ * 
+ * function callback(err: ErrnoException | null, data: string | null) {
+ *   if (err) console.error(err)
+ *   else console.log(data)
+ * }
+ * 
+ * apm.instrument(span, (done) => {
+ *   fs.readFile('example.txt', { encoding: 'utf8' }, done)
+ * }, callback)
+ * ```
+ */
 function instrument<T, CT, CP extends unknown[]>(
   span: SpanOptions,
   run: (done: AsyncCallback<CT, CP>) => T,
   callback: AsyncCallback<CT, CP>,
 ): T
+/**
+ * Instruments synchronous code
+ * 
+ * @param span - Span name or function returning span creation info
+ * @param run - Synchronous code to instrument and run
+ * @param options - Instrumentation options
+ * 
+ * @returns Return value of the instrumented code
+ * 
+ * @example
+ * ```js
+ * instrument('custom', () => fs.readFileSync('example.bin'))
+ * ```
+ */
 function instrument<T>(
   span: SpanOptions,
   run: () => T,
   options?: InstrumentOptions,
 ): T
 
+/**
+ * Instruments async code
+ * 
+ * @param span - Span name or function returning span creation info
+ * @param run - Async code to instrument and run
+ * @param options - Instrumentation options
+ * 
+ * @returns Wrapped promise which will resolve or reject to the same values as the one returned by the instrumented code
+ * 
+ * @example
+ * ```js
+ * const span = () => ({ name: 'custom', kvpairs: { foo: 'bar' } })
+ * 
+ * async function google() {
+ *   const res = await axios.get('https://google.com')
+ *   return res.data
+ * }
+ * 
+ * pInstrument(span, google)
+ *   .then(console.log)
+ *   .catch(console.error)
+ * ```
+ */
 function pInstrument<T>(
   span: SpanOptions,
   run: () => Promise<T>,
   options?: InstrumentOptions,
 ): Promise<T>
 
+/**
+ * Instrumentation continuation options
+ */
 interface InstrumentContinueOptions extends InstrumentOptions {
+  /**
+   * Whether to ignore the existing context and create a new trace
+   */
   forceNewTrace?: boolean
+  /**
+   * Custom transaction name or function returning one
+   */
   customTxName?: string | (() => string)
 }
 
+/**
+ * Starts or continues a trace and instruments callback-style code using it
+ * 
+ * A trace can be continued using a X-Trace ID received from an external source.
+ * For instance this could be HTTP or message queue headers.
+ * 
+ * See {@link instrument} for more details and usage examples.
+ * 
+ * @param traceparent - traceparent ID to continue from
+ * @param tracestate - tracestate ID to continue from
+ * @param span - Span name or function returning span creation info
+ * @param run - Callback-style code to instrument and run receiving the instrumented callback as its sole argument
+ * @param options - Instrumentation options
+ * @param callback - Callback to instrument and pass back to the run function
+ * 
+ * @returns Return value of the instrumented code (not of the callback)
+ */
 function startOrContinueTrace<T, CT, CP extends unknown[]>(
-  traceparent: string,
-  tracestate: string,
+  traceparent: string | null,
+  tracestate: string | null,
   span: SpanOptions,
   run: (done: AsyncCallback<CT, CP>) => T,
   options: InstrumentOptions,
   callback: AsyncCallback<CT, CP>,
 ): T
+/**
+ * Starts or continues a trace and instruments callback-style code using it
+ * 
+ * A trace can be continued using a X-Trace ID received from an external source.
+ * For instance this could be HTTP or message queue headers.
+ * 
+ * See {@link instrument} for more details and usage examples.
+ * 
+ * @param traceparent - traceparent ID to continue from
+ * @param tracestate - tracestate ID to continue from
+ * @param span - Span name or function returning span creation info
+ * @param run - Callback-style code to instrument and run receiving the instrumented callback as its sole argument
+ * @param callback - Callback to instrument and pass back to the run function
+ * 
+ * @returns Return value of the instrumented code (not of the callback)
+ */
 function startOrContinueTrace<T, CT, CP extends unknown[]>(
-  traceparent: string,
-  tracestate: string,
+  traceparent: string | null,
+  tracestate: string | null,
   span: SpanOptions,
   run: (done: AsyncCallback<CT, CP>) => T,
   callback: AsyncCallback<CT, CP>,
 ): T
+/**
+ * Starts or continues a trace and instruments synchronous code using it
+ * 
+ * A trace can be continued using a X-Trace ID received from an external source.
+ * For instance this could be HTTP or message queue headers.
+ * 
+ * See {@link instrument} for more details and usage examples.
+ * 
+ * @param traceparent - traceparent ID to continue from
+ * @param tracestate - tracestate ID to continue from
+ * @param span - Span name or function returning span creation info
+ * @param run - Synchronous code to instrument and run
+ * @param options - Instrumentation options
+ * 
+ * @returns Return value of the instrumented code
+ */
 function startOrContinueTrace<T>(
-  traceparent: string,
-  tracestate: string,
+  traceparent: string | null,
+  tracestate: string | null,
   span: SpanOptions,
   run: () => T,
   options?: InstrumentContinueOptions,
 ): T
 
+/**
+ * Starts or continues a trace and instruments async code using it
+ * 
+ * A trace can be continued using a X-Trace ID received from an external source.
+ * For instance this could be HTTP or message queue headers.
+ * 
+ * See {@link pInstrument} for more details and usage examples.
+ * 
+ * @param traceparent - traceparent ID to continue from
+ * @param tracestate - tracestate ID to continue from
+ * @param span - Span name or function returning span creation info
+ * @param run - Async code to instrument
+ * @param options - Instrumentation options
+ * 
+ * @returns Wrapped promise which will resolve or reject to the same values as the one returned by the instrumented code
+ */
 function pStartOrContinueTrace<T>(
-  traceparent: string,
-  tracestate: string,
+  traceparent: string | null,
+  tracestate: string | null,
   span: SpanOptions,
   run: () => Promise<T>,
   options?: InstrumentContinueOptions,
 ): Promise<T>
 
-function reportInfo(data: KVData): void
+/**
+ * Reports an error in the current trace
+ * 
+ * @param error - Error to report
+ */
 function reportError(error: Error | string): void
+/**
+ * Report an info event in the current trace
+ * 
+ * @param data - The data to report
+ */
+function reportInfo(data: KVData): void
 
+/**
+ * Reportable metric
+ */
 interface Metric {
+  /**
+   * Name of the metric
+   */
   name: string;
+  /**
+   * Count of the metric which defaults to 1
+   */
   count?: number;
-  value?: number;
+  /**
+   * Value of the metric
+   */
+  value: number;
+  /**
+   * Optional tags to attach to the metric
+   */
   tags?: KVData;
-  addHostTag?: boolean;
-}
-interface MetricsOptions {
-  tags?: KVData;
+  /**
+   * Whether to add a host tag before sending the metric
+   */
   addHostTag?: boolean;
 }
 
+/**
+ * Options for sending metrics
+ */
+interface MetricsOptions {
+  /**
+   * Extra tags to be attached to metrics if they are not already defined
+   */
+  tags?: KVData;
+  /**
+   * Whether to add a host tag to metrics before sending them
+   */
+  addHostTag?: boolean;
+}
+
+/**
+ * Sends custom metrics
+ * 
+ * Metrics are aggregated by name and tags and sent every 60 seconds.
+ * 
+ * @param metrics - Metric or array of metrics to send
+ * @param options - Options for sending
+ * 
+ * @returns Object containing an array of metrics that failed to submit
+ * 
+ * @example Send a single metric
+ * ```js
+ * // no value or count provided so defaults to count of 1
+ * apm.sendMetrics({ name: 'basic.count' })
+ * ```
+ * 
+ * @example Send multiple metrics at once
+ * ```js
+ * apm.sendMetrics(
+ *   [
+ *     { name: 'basic.count', count: 2 }, // `basic.count` metric sent as having occured twice
+ *     { name: 'basic.value', value: 10 }, // `basic.value` metric sent as having occurend once with value `10`
+ *     { name: 'basic.both', count: 3, value: 5 }, // `basic.both` metric sent as having occured thrice with value `5` 
+ *   ],
+ *   { tags: { class: 'status' } } // adds a `class` tag with value `status` to each metric unless already specified in the metric itself
+ * )
+ * ```
+ */
 function sendMetrics(metrics: Metric | Metric[], options?: MetricsOptions): { errors: Metric[] }
 
+/**
+ * Object representation of a trace
+ */
 interface TraceObjectForLog {
   trace_id: string;
   span_id: string;
   trace_flags: string;
 }
+/**
+ * Obtains an object representation of the current trace
+ * 
+ * The primary intended use for this is to insert custom metadata in log events.
+ * 
+ * @example Setup log4js to print the current trace info in JSON form
+ * ```js
+ * log4js.addLayout('json', (config) => (logEvent) => {
+ *   logEvent.context = { ...logEvent.context, ...apm.getTraceObjectForLog() }
+ *   return JSON.stringify(logEvent)
+ * })
+ *
+ * log4js.configure({
+ *   appenders: {
+ *     out: { type: 'stdout', layout: { type: 'json' } }
+ *   },
+ *   categories: {
+ *     default: { appenders: ['out'], level: 'info' }
+ *   }
+ * })
+ * 
+ * const logger = log4js.getLogger()
+ * logger.info('doing something')
+ * ```
+ */
 function getTraceObjectForLog(): TraceObjectForLog | null
+/**
+ * Obtains a string representation of the current trace
+ * 
+ * The primary intended use for this is to insert custom metadata in log events.
+ * 
+ * @example Setup log4js to print the current trace info in text form
+ * ```js
+ * log4js.configure({
+ *   appenders: {
+ *     out: {
+ *       type: 'stdout',
+ *       layout: {
+ *         type: 'pattern',
+ *         pattern: '%d %p %c: %m is: %x{trace} %n',
+ *         tokens: {
+ *           trace: apm.getTraceStringForLog
+ *         }
+ *       }
+ *     }
+ *   },
+ *   categories: { default: { appenders: ['out'], level: 'info' } }
+ * })
+ * 
+ * const logger = log4js.getLogger()
+ * logger.info('token from api')
+ * ```
+ */
 function getTraceStringForLog(): string
 
 type LambdaHandler<T, E, C> =
@@ -358,6 +958,33 @@ type LambdaHandler<T, E, C> =
   | ((event: E, context: C) => Promise<T>)
   | ((event: E) => Promise<T>)
 
+/**
+ * Instruments an AWS Lambda handler
+ * 
+ * @param handler - Lambda handler function to instrument
+ * @returns Instrumented async wrapper around the provided handler
+ * 
+ * @example Instrument an async handler
+ * ```js
+ * async function handler(e, ctx) {
+ *   // ...
+ * }
+ * 
+ * const wrapped = apm.wrapLambdaHandler
+ * export { wrapped as handler }
+ * ```
+ * 
+ * @example Instrument a callback-style handler
+ * ```js
+ * function handler(e, ctx, done) {
+ *   // ...
+ *   if (err) done(err)
+ *   else done(null, result)
+ * }
+ * 
+ * exports.handler = apm.wrapLambdaHandler(handler)
+ * ```
+ */
 function wrapLambdaHandler<
   T extends lambda.APIGatewayProxyResult = lambda.APIGatewayProxyResult,
   E extends lambda.APIGatewayEvent = lambda.APIGatewayEvent,

--- a/lib/loggers.d.ts
+++ b/lib/loggers.d.ts
@@ -1,0 +1,51 @@
+import Logger from './debug-custom'
+import { Debugger } from 'debug'
+
+declare namespace loggers {
+
+type Level = 'error' | 'warn' | 'debug' | 'span' | 'info' | 'patching' | 'probes' | 'bind'
+
+interface Debounce {
+  show(): boolean;
+  log(...args: Parameters<Debugger>): void;
+}
+interface DebounceOptions {
+  deltaTime?: number;
+  deltaCount?: number;
+  showDelta?: boolean;
+}
+
+interface LoggerGroupDef {
+  groupName: string;
+  subNames: string[];
+}
+
+interface Loggers {
+  error: Debugger;
+  warn: Debugger;
+  debug: Debugger;
+  span: Debugger;
+  info: Debugger;
+  patching: Debugger;
+  probes: Debugger;
+  bind: Debugger;
+
+  Debounce: new(level: Level, options?: DebounceOptions) => Debounce;
+
+  addGroup(def: LoggerGroupDef): Loggers | undefined;
+  deleteGroup(name: string): true | undefined;
+
+  [name: string]: 
+    | Debugger
+    | { [subname: string]: Debugger }
+    | Loggers['Debounce']
+    | Loggers['addGroup']
+    | Loggers['deleteGroup']
+}
+
+const logger: Logger
+const loggers: Loggers
+
+}
+
+export = loggers

--- a/lib/loggers.d.ts
+++ b/lib/loggers.d.ts
@@ -3,36 +3,113 @@ import { Debugger } from 'debug'
 
 declare namespace loggers {
 
+/**
+ * Builtin log level
+ */
 type Level = 'error' | 'warn' | 'debug' | 'span' | 'info' | 'patching' | 'probes' | 'bind'
 
+/**
+ * Debounced logger
+ */
 interface Debounce {
+  /**
+   * Whether messages will currently be logged
+   */
   show(): boolean;
+  /**
+   * Logs a debounced message
+   */
   log(...args: Parameters<Debugger>): void;
 }
+/**
+ * Debounced logger options
+ */
 interface DebounceOptions {
+  /**
+   * Time span in milliseconds (default 5000)
+   */
   deltaTime?: number;
+  /**
+   * Maximum amount of messages to show in said time span (default 100)
+   */
   deltaCount?: number;
+  /**
+   * Whether to show the message count in the current delta in log messages
+   */
   showDelta?: boolean;
 }
 
+/**
+ * Logger group definition
+ */
 interface LoggerGroupDef {
+  /**
+   * Name of the group
+   */
   groupName: string;
+  /**
+   * Subnames of each logger in the group
+   */
   subNames: string[];
 }
 
+/**
+ * Collection of loggers
+ */
 interface Loggers {
+  /**
+   * Error logger
+   */
   error: Debugger;
+  /**
+   * Warning logger
+   */
   warn: Debugger;
+  /**
+   * Debug logger
+   */
   debug: Debugger;
+  /**
+   * Span logger
+   */
   span: Debugger;
+  /**
+   * Info logger
+   */
   info: Debugger;
+  /**
+   * Patching logger
+   */
   patching: Debugger;
+  /**
+   * Probes logger
+   */
   probes: Debugger;
+  /**
+   * Binding logger
+   */
   bind: Debugger;
 
+  /**
+   * Debounced logger contructor
+   */
   Debounce: new(level: Level, options?: DebounceOptions) => Debounce;
 
+  /**
+   * Adds a new group of loggers
+   * 
+   * @param def - Group definition
+   * 
+   * @returns Updated logger collection
+   */
   addGroup(def: LoggerGroupDef): Loggers | undefined;
+  /**
+   * Deletes an existing group of loggers
+   * 
+   * @param name - Name of the group to delete
+   * 
+   * @returns `true` on success
+   */
   deleteGroup(name: string): true | undefined;
 
   [name: string]: 
@@ -43,7 +120,13 @@ interface Loggers {
     | Loggers['deleteGroup']
 }
 
+/**
+ * Global logger manager instance
+ */
 const logger: Logger
+/**
+ * Global collection of loggers
+ */
 const loggers: Loggers
 
 }

--- a/lib/metrics.d.ts
+++ b/lib/metrics.d.ts
@@ -1,0 +1,26 @@
+type MetricsState = 'initial' | 'started' | 'stopped'
+
+interface MetricsOptions {
+  interval?: number;
+  prefix?: string;
+}
+
+declare class Metrics {
+  constructor(options?: MetricsOptions)
+
+  start(): 'started'
+  stop(): Exclude<MetricsState, 'started'>
+
+  getState(): MetricsState
+  
+  resetInterval(interval: number): void
+
+  addMetricV(metric: string, value: unknown, n?: number): void
+  addMetricI(metric: string, n?: number): void
+
+  reportMetrics(): void
+
+  addMetrics(): void
+  addMemory(): void
+}
+export = Metrics

--- a/lib/metrics.d.ts
+++ b/lib/metrics.d.ts
@@ -1,26 +1,78 @@
+/**
+ * Metrics collector state
+ */
 type MetricsState = 'initial' | 'started' | 'stopped'
 
+/**
+ * Metrics collector option
+ */
 interface MetricsOptions {
+  /**
+   * Interval at which collected metrics are submitted in milliseconds (default 60'000)
+   */
   interval?: number;
+  /**
+   * Prefix added to metrics
+   */
   prefix?: string;
 }
 
+/**
+ * Metrics collector
+ */
 declare class Metrics {
+  /**
+   * @param options - Collector options
+   */
   constructor(options?: MetricsOptions)
 
+  /**
+   * Starts the metrics collector
+   */
   start(): 'started'
+  /**
+   * Stops the metrics collector
+   * 
+   * @returns Current state of the collector
+   */
   stop(): Exclude<MetricsState, 'started'>
 
+  /**
+   * Get the current state of the collector
+   */
   getState(): MetricsState
   
+  /**
+   * Resets the metrics submission interval
+   * 
+   * @param interval - New submission interval in milliseconds
+   */
   resetInterval(interval: number): void
 
+  /**
+   * Adds a value metric to the collector
+   * 
+   * @param metric - Name of the metric
+   * @param value - Value of the metric
+   * @param n - Count of the metric
+   */
   addMetricV(metric: string, value: unknown, n?: number): void
+  /**
+   * Adds a count metric to the collector
+   * 
+   * @param metric - Name of the metric
+   * @param n - Count of the metric
+   */
   addMetricI(metric: string, n?: number): void
 
+  /**
+   * Submits the collected metrics
+   */
   reportMetrics(): void
 
-  addMetrics(): void
+  /**
+   * Collects memory related metrics from node and v8
+   */
   addMemory(): void
 }
 export = Metrics

--- a/lib/span.d.ts
+++ b/lib/span.d.ts
@@ -1,0 +1,36 @@
+import { AsyncWrapper, KVData, TraceSettings } from '.'
+
+declare class Span {
+  constructor(name: string, settings: TraceSettings, data: KVData)
+
+  static makeEntrySpan(name: string, settings: TraceSettings, data: KVData): Span
+
+  descend(name: string, data: KVData): Span
+
+  get async(): boolean
+  set async(async: boolean)
+
+  run<T, WT, WP extends unknown[]>(fn: (wrap: AsyncWrapper<WT, WP>) => T): T
+  run<T>(fn: () => T): T
+
+  runSync<T>(fn: () => T): T
+  runAsync<T, WT, WP extends unknown[]>(fn: (wrap: AsyncWrapper<WT, WP>) => T): T
+  runPromise<T>(pfn: () => Promise<T>, opts?: { collectBacktraces?: boolean }): Promise<T>
+
+  enter(data?: KVData): void
+  exit(data?: KVData): void
+
+  exitCheckingError(error: Error | string, data?: KVData): void
+  setExitError(error: Error | string): void
+
+  info(data: KVData): void
+  error(error: Error | string): void
+
+  setIgnoreErrorFn(fn: (error: Error) => boolean): void
+
+  getTransactionName(): string
+
+  static get last(): Span | undefined | null
+  static set last(span: Span | undefined | null)
+}
+export = Span

--- a/lib/span.d.ts
+++ b/lib/span.d.ts
@@ -1,36 +1,164 @@
-import { AsyncWrapper, KVData, TraceSettings } from '.'
+import { AsyncWrapper, KVData, TraceSettings, getTraceSettings } from '.'
 
+/**
+ * Execution span
+ */
 declare class Span {
+  /**
+   * @param name - Name of the span
+   * @param settings - Settings returned from {@link getTraceSettings}
+   * @param data - Key-value pairs of data to add to the span
+   */
   constructor(name: string, settings: TraceSettings, data: KVData)
 
+  /**
+   * Creates a new entry span
+   * 
+   * The entry span is the top span in a new trace in this process.
+   * It might be continued from another process, for instance if an X-Trace-ID header
+   * was attached to an inbound HTTP/S request
+   * 
+   * @param name - Name of the span
+   * @param settings - Settings returned from {@link getTraceSettings}
+   * @param data - Key-value pairs of data to add to the span
+   */
   static makeEntrySpan(name: string, settings: TraceSettings, data: KVData): Span
 
+  /**
+   * Creates a new span descending from the current span
+   * 
+   * @param name - Name of the span
+   * @param data - Key-value pairs of data to add to the span
+   */
   descend(name: string, data: KVData): Span
 
+  /**
+   * Get whether the span is async
+   */
   get async(): boolean
+  /**
+   * Set whether the span is async
+   */
   set async(async: boolean)
 
+  /**
+   * Runs a callback-style function within the context of this span
+   * 
+   * @param fn - Callback-style function to run receiving a wrapper that must be called on its callback as its sole argument
+   * @returns Return value of the function (not of the callback)
+   * 
+   * @example
+   * ```js
+   * span.run(function (wrap) {
+   *   callToTrace(wrap((err, data) => {
+   *     // ...
+   *   }))
+   * })
+   * ```
+   */
   run<T, WT, WP extends unknown[]>(fn: (wrap: AsyncWrapper<WT, WP>) => T): T
+  /**
+   * Runs a synchronous function within the context of this span
+   * 
+   * @param fn - Synchronous function to run
+   * @returns Return value of the function
+   */
   run<T>(fn: () => T): T
 
-  runSync<T>(fn: () => T): T
-  runAsync<T, WT, WP extends unknown[]>(fn: (wrap: AsyncWrapper<WT, WP>) => T): T
+  /**
+   * Runs an async function within the context of this span
+   * 
+   * @param pfn - Async function to run
+   * @param opts - `collectBacktraces` indicates whether to add a backtrace key-value pair to the span
+   * @returns Wrapped promise which will resolve or reject to the same values as the one returned by the function
+   */
   runPromise<T>(pfn: () => Promise<T>, opts?: { collectBacktraces?: boolean }): Promise<T>
 
+  /**
+   * Runs a synchronous function within the context of this span
+   * 
+   * @param fn - Synchronous function to run
+   * @returns Return value of the function
+   */
+  runSync<T>(fn: () => T): T
+  /**
+   * Runs a callback-style function within the context of this span
+   * 
+   * @param fn - Callback-style function to run receiving a wrapper that must be called on its callback as its sole argument
+   * @returns Return value of the function (not of the callback)
+   */
+  runAsync<T, WT, WP extends unknown[]>(fn: (wrap: AsyncWrapper<WT, WP>) => T): T
+
+  /**
+   * Sends the enter event
+   * 
+   * @param data - Optional key-value pairs to add to the enter event
+   * 
+   * @example Instrumenting a synchronous call
+   * ```js
+   * span.enter()
+   * synchronousCall()
+   * span.exit()
+   * ```
+   * 
+   * @example Instrumenting a callback-style call
+   * ```js
+   * span.enter()
+   * callbackStyleCall(apm.bind(function(err, data) {
+   *   span.exit()
+   *   callback(err, data)
+   * }))
+   * ```
+   */
   enter(data?: KVData): void
+  /**
+   * Sends the exit event
+   * 
+   * @param data - Optional key-value pairs to add to the exit event
+   */
   exit(data?: KVData): void
 
+  /**
+   * Sends the exit event with an error status
+   * 
+   * @param error - Error to add to the event
+   * @param data - Optional key-value pairs to add to the exit event
+   */
   exitCheckingError(error: Error | string, data?: KVData): void
+  /**
+   * Sets an error to be sent with the exit event
+   * 
+   * @param error - Error to add to the event
+   */
   setExitError(error: Error | string): void
 
+  /**
+   * Creates and sends an info event
+   * 
+   * @param data - Kev-value pairs of info
+   */
   info(data: KVData): void
+  /**
+   * Creates and sends an error event
+   * 
+   * @param error - Error to send with the event
+   */
   error(error: Error | string): void
 
-  setIgnoreErrorFn(fn: (error: Error) => boolean): void
-
+  /**
+   * Obtains the transaction name
+   * 
+   * Only top-level spans have transaction names, for others the default value is used.
+   */
   getTransactionName(): string
 
+  /**
+   * Get the last span if any
+   */
   static get last(): Span | undefined | null
+  /**
+   * Set the last span if any
+   */
   static set last(span: Span | undefined | null)
 }
 export = Span

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "supertest": "^3.4.2",
         "tedious": "^14.0.0",
         "testeachversion": "^9.0.0",
+        "typescript": "^4.8.4",
         "winston": "^3.6.0",
         "winston-transport": "^4.5.0",
         "ws": "^7.2.0"
@@ -9839,6 +9840,19 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "node_modules/typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
@@ -18195,6 +18209,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "typical": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,11 @@
       "devDependencies": {
         "@hapi/hapi": "^20.1.5",
         "@hapi/vision": "^6.1.0",
+        "@types/aws-lambda": "^8.10.106",
+        "@types/cls-hooked": "^4.3.3",
+        "@types/debug": "^4.1.7",
+        "@types/express": "^4.17.14",
+        "@types/hapi__hapi": "^20.0.12",
         "amqplib": "^0.8.0",
         "aws-sdk": "^2.1057.0",
         "axios": "^0.26.1",
@@ -76,7 +81,11 @@
         "ws": "^7.2.0"
       },
       "optionalDependencies": {
+<<<<<<< HEAD
         "solarwinds-apm-bindings": "^13.0.0"
+=======
+        "solarwinds-apm-bindings": "^13.0.0-prerelease.1"
+>>>>>>> 5926d55b (fix kvdata type and force update package lock)
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -927,6 +936,27 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -936,10 +966,116 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.106",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.106.tgz",
+      "integrity": "sha512-yzgMaql7aW1by1XuhKhovuhLyK/1A60lapFXDXXBeHmoyRGQFO2T8lkL3g8hAhHoW5PEvqPJFWPd8jvXiRnxeQ==",
+      "dev": true
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/bson": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
       "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cls-hooked": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.3.tgz",
+      "integrity": "sha512-gNstDTb/ty5h6gJd6YpSPgsLX9LmRpaKJqGFp7MRlYxhwp4vXXKlJ9+bt1TZ9KbVNXE+Mbxy2AYXcpY21DDtJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.31",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
+      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/hapi__catbox": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.4.tgz",
+      "integrity": "sha512-A6ivRrXD5glmnJna1UAGw87QNZRp/vdFO9U4GS+WhOMWzHnw+oTGkMvg0g6y1930CbeheGOCm7A1qHsqH7AXqg==",
+      "dev": true
+    },
+    "node_modules/@types/hapi__hapi": {
+      "version": "20.0.12",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.12.tgz",
+      "integrity": "sha512-B+0fceCzFvbIOVv5YWOZzbHtEff8BLlGH3etrkcOedyj7F0unC5FjzFfaaO5gwlhJDdX0cmmMeRg2pwRdMa2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/boom": "^9.0.0",
+        "@hapi/iron": "^6.0.0",
+        "@hapi/podium": "^4.1.3",
+        "@types/hapi__catbox": "*",
+        "@types/hapi__mimos": "*",
+        "@types/hapi__shot": "*",
+        "@types/node": "*",
+        "joi": "^17.3.0"
+      }
+    },
+    "node_modules/@types/hapi__mimos": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.4.tgz",
+      "integrity": "sha512-i9hvJpFYTT/qzB5xKWvDYaSXrIiNqi4ephi+5Lo6+DoQdwqPXQgmVVOZR+s3MBiHoFqsCZCX9TmVWG3HczmTEQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime-db": "*"
+      }
+    },
+    "node_modules/@types/hapi__shot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.2.tgz",
+      "integrity": "sha512-8wWgLVP1TeGqgzZtCdt+F+k15DWQvLG1Yv6ZzPfb3D5WIo5/S+GGKtJBVo2uNEcqabP5Ifc71QnJTDnTmw1axA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -979,6 +1115,18 @@
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
     },
+    "node_modules/@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
+    "node_modules/@types/mime-db": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.1.tgz",
+      "integrity": "sha512-kGZJY+R+WnR5Rk+RPHUMERtb2qBRViIHCBdtUrY+NmwuGb8pQdfTqQiCKPrxpdoycl8KWm2DLdkpoSdt479XoQ==",
+      "dev": true
+    },
     "node_modules/@types/mongodb": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
@@ -988,6 +1136,12 @@
         "@types/bson": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "17.0.23",
@@ -1017,6 +1171,28 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/tunnel": {
@@ -5113,6 +5289,19 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/joi": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.2.tgz",
+      "integrity": "sha512-+gqqdh1xc1wb+Lor0J9toqgeReyDOCqOdG8QSdRcEvwrcRiFQZneUCGKjFjuyBWUb3uaFOgY56yMaZ5FIc+H4w==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -8740,9 +8929,15 @@
       }
     },
     "node_modules/solarwinds-apm-bindings": {
+<<<<<<< HEAD
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0.tgz",
       "integrity": "sha512-XSLO9+go4YvxBSox0rEsm1P1KmmkqIuhfq7GMQRFsYFCLYD8JV+/SatZn9rR36+AnUOLZCdtj0kZfVQ/OjrHrw==",
+=======
+      "version": "13.0.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0-prerelease.1.tgz",
+      "integrity": "sha512-AAyGTAVdGFsNo/wYqDyzZfaFkmM5oooYRwWugKfYtQSB3HN85RCqpIGwUWN2zKZ3bgSd0H+Sv0lLnrULboLqmw==",
+>>>>>>> 5926d55b (fix kvdata type and force update package lock)
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -10954,16 +11149,143 @@
       "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
       "dev": true
     },
+    "@sideway/address": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
+      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+      "integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/aws-lambda": {
+      "version": "8.10.106",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.106.tgz",
+      "integrity": "sha512-yzgMaql7aW1by1XuhKhovuhLyK/1A60lapFXDXXBeHmoyRGQFO2T8lkL3g8hAhHoW5PEvqPJFWPd8jvXiRnxeQ==",
+      "dev": true
+    },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/bson": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
       "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/cls-hooked": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.3.tgz",
+      "integrity": "sha512-gNstDTb/ty5h6gJd6YpSPgsLX9LmRpaKJqGFp7MRlYxhwp4vXXKlJ9+bt1TZ9KbVNXE+Mbxy2AYXcpY21DDtJw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.14.tgz",
+      "integrity": "sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.31",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
+      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/hapi__catbox": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.4.tgz",
+      "integrity": "sha512-A6ivRrXD5glmnJna1UAGw87QNZRp/vdFO9U4GS+WhOMWzHnw+oTGkMvg0g6y1930CbeheGOCm7A1qHsqH7AXqg==",
+      "dev": true
+    },
+    "@types/hapi__hapi": {
+      "version": "20.0.12",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.12.tgz",
+      "integrity": "sha512-B+0fceCzFvbIOVv5YWOZzbHtEff8BLlGH3etrkcOedyj7F0unC5FjzFfaaO5gwlhJDdX0cmmMeRg2pwRdMa2CQ==",
+      "dev": true,
+      "requires": {
+        "@hapi/boom": "^9.0.0",
+        "@hapi/iron": "^6.0.0",
+        "@hapi/podium": "^4.1.3",
+        "@types/hapi__catbox": "*",
+        "@types/hapi__mimos": "*",
+        "@types/hapi__shot": "*",
+        "@types/node": "*",
+        "joi": "^17.3.0"
+      }
+    },
+    "@types/hapi__mimos": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.4.tgz",
+      "integrity": "sha512-i9hvJpFYTT/qzB5xKWvDYaSXrIiNqi4ephi+5Lo6+DoQdwqPXQgmVVOZR+s3MBiHoFqsCZCX9TmVWG3HczmTEQ==",
+      "dev": true,
+      "requires": {
+        "@types/mime-db": "*"
+      }
+    },
+    "@types/hapi__shot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.2.tgz",
+      "integrity": "sha512-8wWgLVP1TeGqgzZtCdt+F+k15DWQvLG1Yv6ZzPfb3D5WIo5/S+GGKtJBVo2uNEcqabP5Ifc71QnJTDnTmw1axA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -11003,6 +11325,18 @@
       "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
       "dev": true
     },
+    "@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "dev": true
+    },
+    "@types/mime-db": {
+      "version": "1.43.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.1.tgz",
+      "integrity": "sha512-kGZJY+R+WnR5Rk+RPHUMERtb2qBRViIHCBdtUrY+NmwuGb8pQdfTqQiCKPrxpdoycl8KWm2DLdkpoSdt479XoQ==",
+      "dev": true
+    },
     "@types/mongodb": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
@@ -11012,6 +11346,12 @@
         "@types/bson": "*",
         "@types/node": "*"
       }
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
     },
     "@types/node": {
       "version": "17.0.23",
@@ -11040,6 +11380,28 @@
             "mime-types": "^2.1.12"
           }
         }
+      }
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+      "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "*",
+        "@types/node": "*"
       }
     },
     "@types/tunnel": {
@@ -14225,6 +14587,19 @@
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "dev": true
     },
+    "joi": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.6.2.tgz",
+      "integrity": "sha512-+gqqdh1xc1wb+Lor0J9toqgeReyDOCqOdG8QSdRcEvwrcRiFQZneUCGKjFjuyBWUb3uaFOgY56yMaZ5FIc+H4w==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.0",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -17104,9 +17479,15 @@
       }
     },
     "solarwinds-apm-bindings": {
+<<<<<<< HEAD
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0.tgz",
       "integrity": "sha512-XSLO9+go4YvxBSox0rEsm1P1KmmkqIuhfq7GMQRFsYFCLYD8JV+/SatZn9rR36+AnUOLZCdtj0kZfVQ/OjrHrw==",
+=======
+      "version": "13.0.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0-prerelease.1.tgz",
+      "integrity": "sha512-AAyGTAVdGFsNo/wYqDyzZfaFkmM5oooYRwWugKfYtQSB3HN85RCqpIGwUWN2zKZ3bgSd0H+Sv0lLnrULboLqmw==",
+>>>>>>> 5926d55b (fix kvdata type and force update package lock)
       "optional": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,11 +81,7 @@
         "ws": "^7.2.0"
       },
       "optionalDependencies": {
-<<<<<<< HEAD
         "solarwinds-apm-bindings": "^13.0.0"
-=======
-        "solarwinds-apm-bindings": "^13.0.0-prerelease.1"
->>>>>>> 5926d55b (fix kvdata type and force update package lock)
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -8929,15 +8925,9 @@
       }
     },
     "node_modules/solarwinds-apm-bindings": {
-<<<<<<< HEAD
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0.tgz",
       "integrity": "sha512-XSLO9+go4YvxBSox0rEsm1P1KmmkqIuhfq7GMQRFsYFCLYD8JV+/SatZn9rR36+AnUOLZCdtj0kZfVQ/OjrHrw==",
-=======
-      "version": "13.0.0-prerelease.1",
-      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0-prerelease.1.tgz",
-      "integrity": "sha512-AAyGTAVdGFsNo/wYqDyzZfaFkmM5oooYRwWugKfYtQSB3HN85RCqpIGwUWN2zKZ3bgSd0H+Sv0lLnrULboLqmw==",
->>>>>>> 5926d55b (fix kvdata type and force update package lock)
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -17479,15 +17469,9 @@
       }
     },
     "solarwinds-apm-bindings": {
-<<<<<<< HEAD
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0.tgz",
       "integrity": "sha512-XSLO9+go4YvxBSox0rEsm1P1KmmkqIuhfq7GMQRFsYFCLYD8JV+/SatZn9rR36+AnUOLZCdtj0kZfVQ/OjrHrw==",
-=======
-      "version": "13.0.0-prerelease.1",
-      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0-prerelease.1.tgz",
-      "integrity": "sha512-AAyGTAVdGFsNo/wYqDyzZfaFkmM5oooYRwWugKfYtQSB3HN85RCqpIGwUWN2zKZ3bgSd0H+Sv0lLnrULboLqmw==",
->>>>>>> 5926d55b (fix kvdata type and force update package lock)
       "optional": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "./test.sh",
     "test:core": "./test.sh CORE",
     "test:probes": "./test.sh PROBES",
+    "test:types": "./test.sh TYPES",
     "docs:api": "cat lib/index.js lib/api.js lib/span.js lib/event.js > api-docs-temp.js && jsdoc2md -f api-docs-temp.js > docs/api.md && rm api-docs-temp.js",
     "lint": "eslint . --ext .json,.js,.yml --fix --ignore-pattern bench --ignore-pattern test/docker",
     "dev": "dev/start.sh",
@@ -115,6 +116,7 @@
     "supertest": "^3.4.2",
     "tedious": "^14.0.0",
     "testeachversion": "^9.0.0",
+    "typescript": "^4.8.4",
     "winston": "^3.6.0",
     "winston-transport": "^4.5.0",
     "ws": "^7.2.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "11.1.0",
   "description": "Agent for SolarWinds APM",
   "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "types": "lib/index.d.ts",
   "files": [
     "lib",
     "solarwinds-apm-config.json",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "11.1.0",
   "description": "Agent for SolarWinds APM",
   "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "files": [
     "lib",
     "solarwinds-apm-config.json",
@@ -55,6 +56,9 @@
   "devDependencies": {
     "@hapi/hapi": "^20.1.5",
     "@hapi/vision": "^6.1.0",
+    "@types/aws-lambda": "^8.10.106",
+    "@types/cls-hooked": "^4.3.3",
+    "@types/debug": "^4.1.7",
     "amqplib": "^0.8.0",
     "aws-sdk": "^2.1057.0",
     "axios": "^0.26.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "@types/aws-lambda": "^8.10.106",
     "@types/cls-hooked": "^4.3.3",
     "@types/debug": "^4.1.7",
+    "@types/express": "^4.17.14",
+    "@types/hapi__hapi": "^20.0.12",
     "amqplib": "^0.8.0",
     "aws-sdk": "^2.1057.0",
     "axios": "^0.26.1",

--- a/test.sh
+++ b/test.sh
@@ -147,6 +147,20 @@ if [ "$group_to_run" = "LAMBDA" ] || [ ! "$group_to_run" ]; then executeTestGrou
 #
 if [ "$group_to_run" = "PROBES" ] || [ ! "$group_to_run" ]; then executeTestGroup "PROBES" "test/probes/*.test.js"; fi
 
+#
+# this runs the type definitions tests which use tsc and not mocha
+#
+if [ "$group_to_run" = "TYPES" ] || [ ! "$group_to_run" ] && executeGroup "TYPES"; then
+    if ! tsc --noEmit --esModuleInterop test/types.test.ts; then
+        SUITES_FAILED=$((SUITES_FAILED + 1))
+        GROUPS_FAILED=$((GROUPS_FAILED + 1))
+        addError "$TYPES"
+    else
+        SUITES_PASSED=$((SUITES_PASSED + 1))
+        GROUPS_PASSED=$((GROUPS_PASSED + 1))
+    fi
+fi
+
 #=======================================
 # provide a summary of the test results.
 #=======================================

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,450 @@
+// This file is not actually meant to be run but only typechecked using tsc
+// to make sure the type declarations fit the expected usage.
+
+import apm from '..'
+import * as events from 'node:events'
+import * as fs from 'node:fs'
+import * as http from 'node:http'
+import * as lambda from 'aws-lambda'
+
+let nil: null
+let pnil: Promise<null>
+
+let kv: apm.KVData
+kv = {}
+kv = { s: 'string' }
+kv = { n: 0 }
+kv = { b: true }
+kv = { e: new Error() }
+// @ts-expect-error
+kv = { invalid: [] }
+// @ts-expect-error
+kv = { invalid: {} }
+
+let traceSettings: apm.TraceSettings
+traceSettings = apm.getTraceSettings('parent', 'state')
+traceSettings = apm.getTraceSettings('parent', 'state', {})
+traceSettings = apm.getTraceSettings('parent', 'state', 10)
+
+const event: apm.Event = new apm.Event('span', 'label')
+let span: apm.Span = new apm.Span('name', traceSettings, kv)
+const metrics: apm.Metrics = new apm.Metrics()
+
+const request = new http.ClientRequest('url')
+const response = new http.ServerResponse({} as http.IncomingMessage)
+
+const version: string = apm.version
+// @ts-expect-error
+apm.version = 'version'
+
+const root: string = apm.root
+// @ts-expect-error
+apm.root = 'root'
+
+const logLevel: string = apm.logLevel
+apm.logLevel = 'level'
+
+let logLevels: string
+logLevels = apm.logLevelAdd('info,debug')
+logLevels = apm.logLevelAdd(['info', 'debug'])
+logLevels = apm.logLevelRemove('info,debug')
+logLevels = apm.logLevelRemove(['info', 'debug'])
+
+const config: apm.Config = apm.cfg
+const execEnv: apm.ExecEnv = apm.execEnv
+
+const logMissing = apm.makeLogMissing("name")
+logMissing("missing")
+logMissing(new Error())
+
+apm.traceMode = 0
+apm.traceMode = 1
+apm.traceMode = 'never'
+apm.traceMode = 'always'
+apm.traceMode = 'disabled'
+apm.traceMode = 'enabled'
+// @ts-expect-error
+apm.traceMode = 2
+// @ts-expect-error
+apm.traceMode = 'no'
+// @ts-expect-error
+apm.traceMode = 'yes'
+
+const sampleRate: number = apm.sampleRate
+apm.sampleRate = 100_000
+
+const tracing: boolean = apm.tracing
+// @ts-expect-error
+apm.tracing = true
+
+const traceId: string | undefined = apm.traceId
+// @ts-expect-error
+apm.traceId = 'id'
+
+let lastEvent: apm.Event | null | undefined = apm.lastEvent
+apm.lastEvent = event
+apm.lastEvent = null
+apm.lastEvent = undefined
+
+let lastSpan: apm.Span | null | undefined = apm.lastSpan
+apm.lastSpan = span
+apm.lastSpan = null
+apm.lastSpan = undefined
+
+let stack: string
+stack = apm.stack('text')
+stack = apm.stack('text', 10)
+
+const backtrace: string = apm.backtrace()
+
+let bound: Function
+bound = apm.bind(() => {})
+bound = apm.bind(function() {})
+
+const boundEmitter: events.EventEmitter = apm.bindEmitter(new events.EventEmitter())
+
+apm.setCustomTxNameFunction('express', (req, res) => 'name')
+apm.setCustomTxNameFunction('express', (req, res) => false)
+// @ts-expect-error
+apm.setCustomTxNameFunction('express', (req, res) => true)
+apm.setCustomTxNameFunction('@hapi/hapi', (req) => 'name')
+apm.setCustomTxNameFunction('@hapi/hapi', (req) => false)
+// @ts-expect-error
+apm.setCustomTxNameFunction('@hapi/hapi', (req) => true)
+
+let readyToSample: boolean
+readyToSample = apm.readyToSample()
+readyToSample = apm.readyToSample(1000)
+readyToSample = apm.readyToSample(1000, { status: undefined })
+
+let sampling: boolean
+sampling = apm.sampling('traceid')
+sampling = apm.sampling(event)
+
+apm.patchResponse(response)
+apm.addResponseFinalizer(response, () => {})
+
+let spanInfo: apm.SpanInfo
+spanInfo = {
+    name: 'name',
+}
+spanInfo = {
+    name: 'name',
+    kvpairs: kv,
+}
+spanInfo = {
+    name: 'name',
+    finalize(span: apm.Span, last: apm.Span) {},
+}
+// @ts-expect-error
+spanInfo = {}
+
+let spanOptions: apm.SpanOptions
+spanOptions = 'span'
+spanOptions = () => spanInfo
+// @ts-expect-error
+spanOptions = spanInfo
+
+let instrumentOptions: apm.InstrumentOptions
+instrumentOptions = {}
+instrumentOptions = { enabled: true }
+instrumentOptions = { collectBacktraces: true }
+
+nil = apm.instrumentHttp(
+    spanOptions,
+    () => null,
+    instrumentOptions,
+    response
+)
+
+nil = apm.instrument(
+    spanOptions,
+    (done) => {
+        fs.readFile('file', done)
+        return null
+    },
+    instrumentOptions,
+    (err: NodeJS.ErrnoException | null, data: Buffer) => {}
+)
+nil = apm.instrument(
+    spanOptions,
+    (done) => {
+        // @ts-expect-error
+        fs.readFile('file', done)
+        return null
+    },
+    instrumentOptions,
+    (err: null, data: string) => {}
+)
+nil = apm.instrument(
+    spanOptions,
+    (done) => {
+        fs.readFile('file', done)
+        return null
+    },
+    (err: NodeJS.ErrnoException | null, data: Buffer) => {}
+)
+
+nil = apm.instrument(spanOptions, () => null)
+nil = apm.instrument(spanOptions, () => null, instrumentOptions)
+// @ts-expect-error
+nil = apm.instrument(spanOptions, () => true)
+
+pnil = apm.pInstrument(spanOptions, async () => null)
+pnil = apm.pInstrument(spanOptions, async () => null, instrumentOptions)
+pnil = apm.pInstrument(spanOptions, () => Promise.resolve(null))
+// @ts-expect-error
+pnil = apm.pInstrument(spanOptions, async () => true)
+
+let instrumentContinueOptions: apm.InstrumentContinueOptions
+instrumentContinueOptions = {}
+instrumentContinueOptions = { enabled: true }
+instrumentContinueOptions = { collectBacktraces: true }
+instrumentContinueOptions = { forceNewTrace: true }
+instrumentContinueOptions = { customTxName: 'name' }
+instrumentContinueOptions = { customTxName: () => 'name' }
+// @ts-expect-error
+instrumentContinueOptions = { customTxName: () => false }
+
+nil = apm.startOrContinueTrace(
+    'parent',
+    'state',
+    spanOptions,
+    (done) => {
+        fs.readFile('file', done)
+        return null
+    },
+    instrumentContinueOptions,
+    (err: NodeJS.ErrnoException | null, data: Buffer) => {}
+)
+nil = apm.startOrContinueTrace(
+    'parent',
+    null,
+    spanOptions,
+    (done) => {
+        // @ts-expect-error
+        fs.readFile('file', done)
+        return null
+    },
+    instrumentContinueOptions,
+    (err: null, data: string) => {}
+)
+nil = apm.startOrContinueTrace(
+    null,
+    'state',
+    spanOptions,
+    (done) => {
+        fs.readFile('file', done)
+        return null
+    },
+    (err: NodeJS.ErrnoException | null, data: Buffer) => {}
+)
+
+nil = apm.startOrContinueTrace('parent', 'state', spanOptions, () => null)
+nil = apm.startOrContinueTrace(null, null, spanOptions, () => null, instrumentContinueOptions)
+// @ts-expect-error
+nil = apm.startOrContinueTrace('parent', 'state', spanOptions, () => true)
+
+pnil = apm.pStartOrContinueTrace('parent', 'state', spanOptions, async () => null)
+pnil = apm.pStartOrContinueTrace('parent', null, spanOptions, async () => null, instrumentContinueOptions)
+pnil = apm.pStartOrContinueTrace(null, 'state', spanOptions, () => Promise.resolve(null))
+// @ts-expect-error
+pnil = apm.pStartOrContinueTrace(spanOptions, async () => true)
+// @ts-expect-error
+apm.pStartOrContinueTrace(spanOptions, () => null)
+
+apm.reportError('error')
+apm.reportError(new Error())
+
+apm.reportInfo(kv)
+// @ts-expect-error
+apm.reportInfo('info')
+
+let metric: apm.Metric
+metric = {
+    name: 'name',
+    count: 2,
+}
+metric = {
+    name: 'name',
+    value: 2,
+}
+metric = {
+    name: 'name',
+    tags: kv,
+    addHostTag: true,
+}
+// @ts-expect-error
+metric = {
+    count: 2,
+}
+metric = {
+    name: 'name',
+    // @ts-expect-error
+    value: 'value',
+}
+
+let metricsOptions: apm.MetricsOptions
+metricsOptions = {}
+metricsOptions = { tags: kv }
+metricsOptions = { addHostTag: true }
+
+let metricsResult: { errors: apm.Metric[] }
+metricsResult = apm.sendMetrics(metric)
+metricsResult = apm.sendMetrics(metric, metricsOptions)
+metricsResult = apm.sendMetrics([metric])
+metricsResult = apm.sendMetrics([metric], metricsOptions)
+// @ts-expect-error
+metricsResult = apm.sendMetrics('metric')
+// @ts-expect-error
+metricsResult = apm.sendMetrics(['metric'])
+
+const traceObjectForLog = apm.getTraceObjectForLog()
+const tofl_trace_id: string = traceObjectForLog!.trace_id
+const tofl_span_id: string = traceObjectForLog!.span_id
+const tofl_trace_flags: string = traceObjectForLog!.trace_flags
+
+const traceStringForLog: string = apm.getTraceStringForLog()
+
+let handler: lambda.APIGatewayProxyHandler = async (event, ctx) => ({ statusCode: 200, body: 'hi' }) 
+handler = apm.wrapLambdaHandler(handler)
+
+// *** LOGGING
+
+apm.loggers.debug('debug')
+apm.loggers.info('info')
+apm.loggers.warn('warn')
+apm.loggers.error('error')
+apm.loggers.span('span')
+apm.loggers.patching('patching')
+apm.loggers.bind('bind')
+apm.loggers.probes('probes')
+
+let debounced = new apm.loggers.Debounce('info')
+debounced = new apm.loggers.Debounce('patching', {
+    deltaTime: 5000,
+    deltaCount: 100,
+    showDelta: true,
+})
+// @ts-expect-error
+debounced = new apm.loggers.Debounce('custom')
+
+apm.loggers.addGroup({
+    groupName: 'group',
+    subNames: ['logger']
+})
+// @ts-expect-error
+apm.loggers.addGroup('group')
+
+apm.loggers.deleteGroup('group')
+
+const loggerName: string = apm.logger.name
+apm.logger.name = 'name'
+
+const loggerLogLevel: string = apm.logger.logLevel
+apm.logger.logLevel = 'level'
+apm.logger.logLevel = ['level']
+
+let loggerLogLevels: string
+loggerLogLevels = apm.logger.addEnabled('info,debug')
+loggerLogLevels = apm.logger.addEnabled(['info', 'debug'])
+loggerLogLevels = apm.logger.removeEnabled('info,debug')
+loggerLogLevels = apm.logger.removeEnabled(['info', 'debug'])
+
+const loggerHas: boolean = apm.logger.has('level')
+
+const newLogger = apm.logger.make('level')
+const enabledNewLogger = apm.logger.make('level', true)
+
+// *** EVENT
+
+// @ts-expect-error
+new apm.Event()
+
+event.error = 'error'
+event.error = new Error()
+
+const eventTaskId: string = event.taskId
+// @ts-expect-error
+event.taskId = 'id'
+
+const eventOpId: string = event.opId
+// @ts-expect-error
+event.opId = 'id'
+
+event.set(kv)
+
+const eventString: string = event.toString()
+
+event.sendReport()
+event.sendReport(kv)
+
+lastEvent = apm.Event.last
+apm.Event.last = event
+apm.Event.last = undefined
+apm.Event.last = null
+
+// *** SPAN
+
+// @ts-expect-error
+span = new apm.Span()
+
+span = apm.Span.makeEntrySpan('name', traceSettings, kv)
+// @ts-expect-error
+span = apm.Span.makeEntrySpan()
+
+span = span.descend('name', kv)
+
+const spanAsync: boolean = span.async
+span.async = true
+span.async = false
+
+nil = span.run<null, void, [string, number]>((wrap) => {
+    wrap((s: string, n: number) => {})
+    return null
+})
+nil = span.run<null, void, [string, boolean]>((wrap) => {
+    // @ts-expect-error
+    wrap((s: string, n: number) => {})
+    return null
+})
+// @ts-expect-error
+nil = span.run((wrap) => {
+    wrap((...args) => {})
+})
+
+nil = span.run(() => null)
+// @ts-expect-error
+nil = span.run(() => true)
+
+pnil = span.runPromise(async () => null)
+pnil = span.runPromise(() => Promise.resolve(null))
+// @ts-expect-error
+pnil = span.runPromise(async () => true)
+// @ts-expect-error
+span.runPromise(() => true)
+
+span.enter()
+span.enter(kv)
+
+span.exit()
+span.exit(kv)
+
+span.exitCheckingError('error')
+span.exitCheckingError(new Error())
+span.exitCheckingError(new Error(), kv)
+
+span.setExitError('error')
+span.setExitError(new Error())
+
+span.info(kv)
+
+span.error('error')
+span.error(new Error())
+
+const spanTxName = span.getTransactionName()
+
+lastSpan = apm.Span.last
+apm.Span.last = span
+apm.Span.last = null
+apm.Span.last = undefined


### PR DESCRIPTION
This "just" adds type declarations to the public facing API. There are no functional changes, just a lot of types and a lot of documentation comments.
Some of the type declarations (especially those related to instrumenting callback-style code) are fairly convoluted as to preserve type information and avoid decaying to `any` or `unknown`, which would be very impractical for users.