### PR TITLE
11.1.0-prerelease.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## SolarWinds APM changelog
 
-
 v11.0.0 is the first SolarWinds APM version. Versions prior to v11.0.0 were branded AppOptics APM. See: https://github.com/appoptics/appoptics-apm-node/blob/master/CHANGELOG.md
+
+### Unreleased
+
+Features
+- Add `metricFormat` configuration option for advanced use.
+- Update native bindings to support new metrics format.
 
 ### v11.0.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solarwinds-apm",
-  "version": "11.0.0",
+  "version": "11.1.0-prerelease.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solarwinds-apm",
-      "version": "11.0.0",
+      "version": "11.1.0-prerelease.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ace-context": "^1.0.1",
@@ -76,7 +76,7 @@
         "ws": "^7.2.0"
       },
       "optionalDependencies": {
-        "solarwinds-apm-bindings": "^12.0.0"
+        "solarwinds-apm-bindings": "^13.0.0-prerelease.1"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -8740,9 +8740,9 @@
       }
     },
     "node_modules/solarwinds-apm-bindings": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-12.0.0.tgz",
-      "integrity": "sha512-GgQlS8boONmu8lCWQpPWyoP5WOK3+y0b5e8Sw+4LMI9u1FuYybsP5z1Sqt+oOnPoZVKdS9YI2onx8cws1yJk1g==",
+      "version": "13.0.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0-prerelease.1.tgz",
+      "integrity": "sha512-AAyGTAVdGFsNo/wYqDyzZfaFkmM5oooYRwWugKfYtQSB3HN85RCqpIGwUWN2zKZ3bgSd0H+Sv0lLnrULboLqmw==",
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -17104,9 +17104,9 @@
       }
     },
     "solarwinds-apm-bindings": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-12.0.0.tgz",
-      "integrity": "sha512-GgQlS8boONmu8lCWQpPWyoP5WOK3+y0b5e8Sw+4LMI9u1FuYybsP5z1Sqt+oOnPoZVKdS9YI2onx8cws1yJk1g==",
+      "version": "13.0.0-prerelease.1",
+      "resolved": "https://registry.npmjs.org/solarwinds-apm-bindings/-/solarwinds-apm-bindings-13.0.0-prerelease.1.tgz",
+      "integrity": "sha512-AAyGTAVdGFsNo/wYqDyzZfaFkmM5oooYRwWugKfYtQSB3HN85RCqpIGwUWN2zKZ3bgSd0H+Sv0lLnrULboLqmw==",
       "optional": true,
       "requires": {
         "@mapbox/node-pre-gyp": "^1.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solarwinds-apm",
-  "version": "11.0.0",
+  "version": "11.1.0-prerelease.1",
   "description": "Agent for SolarWinds APM",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
This prerelease includes the bindings update to liboboe 10.6.1 and the new `metricFormat` setting and detection of its default value.