### PR TITLE
Fix pg probe tests

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -63,7 +63,6 @@ services:
       - "9042:9042"
 
   memcached:
-    platform: linux/amd64
     container_name: "memcached"
     image: memcached 
     ports:
@@ -77,7 +76,6 @@ services:
       - "27017:27017"
 
   mongo_3:
-    platform: linux/amd64
     container_name: "mongo_3"
     image: mongo:3 
     ports:
@@ -85,7 +83,6 @@ services:
       - "27018:27017"
 
   mongo_4:
-    platform: linux/amd64
     container_name: "mongo_4"
     image: mongo:4 
     ports:
@@ -93,7 +90,6 @@ services:
       - "27019:27017"
 
   mongo_5:
-    platform: linux/amd64
     container_name: "mongo_5"
     image: mongo:5 
     ports:
@@ -126,7 +122,6 @@ services:
       - "1521:1521"
 
   postgres:
-    platform: linux/amd64
     container_name: "postgres"
     image: "postgres"
     ports:
@@ -135,7 +130,6 @@ services:
       - POSTGRES_PASSWORD=xyzzy
 
   rabbitmq:
-    platform: linux/amd64
     container_name: "rabbitmq" 
     image: rabbitmq:3-management 
     ports:
@@ -143,7 +137,6 @@ services:
       - "5671:5671"
 
   redis:
-    platform: linux/amd64
     container_name: "redis"
     image: redis  
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "mongoose": "^5.13.9",
         "morgan": "^1.10.0",
         "mysql": "^2.18.1",
-        "oracledb": "^5.2.0",
+        "oracledb": "https://github.com/oracle/node-oracledb/releases/download/v5.5.0/oracledb-src-5.5.0.tgz",
         "pg": "^8.7.1",
         "pg-native": "^3.0.0",
         "pino": "^7.8.0",
@@ -7471,11 +7471,11 @@
       }
     },
     "node_modules/oracledb": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-5.3.0.tgz",
-      "integrity": "sha512-HMJzQ6lCf287ztvvehTEmjCWA21FQ3RMvM+mgoqd4i8pkREuqFWO+y3ovsGR9moJUg4T0xjcwS8rl4mggWPxmg==",
+      "version": "5.5.0",
+      "resolved": "https://github.com/oracle/node-oracledb/releases/download/v5.5.0/oracledb-src-5.5.0.tgz",
+      "integrity": "sha512-ZfQiqrofTxq3B916RqGEMqaldQj+INqlbM2W2blZhr4SfcZcJU/JRJFwDMzJCEB+b0v1fqD/MFAmSvB9GEYENA==",
       "dev": true,
-      "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=10.16"
       }
@@ -16528,9 +16528,8 @@
       }
     },
     "oracledb": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-5.3.0.tgz",
-      "integrity": "sha512-HMJzQ6lCf287ztvvehTEmjCWA21FQ3RMvM+mgoqd4i8pkREuqFWO+y3ovsGR9moJUg4T0xjcwS8rl4mggWPxmg==",
+      "version": "https://github.com/oracle/node-oracledb/releases/download/v5.5.0/oracledb-src-5.5.0.tgz",
+      "integrity": "sha512-ZfQiqrofTxq3B916RqGEMqaldQj+INqlbM2W2blZhr4SfcZcJU/JRJFwDMzJCEB+b0v1fqD/MFAmSvB9GEYENA==",
       "dev": true
     },
     "p-limit": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "mongoose": "^5.13.9",
     "morgan": "^1.10.0",
     "mysql": "^2.18.1",
-    "oracledb": "^5.2.0",
+    "oracledb": "https://github.com/oracle/node-oracledb/releases/download/v5.5.0/oracledb-src-5.5.0.tgz",
     "pg": "^8.7.1",
     "pg-native": "^3.0.0",
     "pino": "^7.8.0",

--- a/test/helper.js
+++ b/test/helper.js
@@ -154,6 +154,10 @@ exports.doChecks = function (emitter, checks, done, opt = {}) {
     if (!emitter.__apmActive) {
       log.test.messages('mock (' + addr.port + ') received message', msg)
     }
+    if (opt.skip && opt.skip(msg)) {
+      return
+    }
+
     const check = checks.shift()
     if (opt.debug) {
       // eslint-disable-next-line no-console
@@ -253,7 +257,7 @@ exports.aggregate = function (emitter, config, done) {
   emitter.on('message', onMessage)
 }
 
-exports.test = function (emitter, test, validations, done) {
+exports.test = function (emitter, test, validations, done, opt = {}) {
   function noop () {}
   // noops skip testing the 'outer' span.
   /*
@@ -282,7 +286,7 @@ exports.test = function (emitter, test, validations, done) {
     delete emitter[apmAggregate]
   } else {
     // check messages as the occur using the validations array.
-    exports.doChecks(emitter, validations, done)
+    exports.doChecks(emitter, validations, done, opt)
   }
 
   apm.requestStore.run(function () {

--- a/test/probes/pg.test.js
+++ b/test/probes/pg.test.js
@@ -3,6 +3,7 @@
 
 const helper = require('../helper')
 const { apm } = require('../1.test-common')
+const semver = require('semver')
 
 const postgres = require('pg')
 const pkg = require('pg/package.json')
@@ -20,6 +21,16 @@ const auth = {
   user: process.env.SW_APM_TEST_POSTGRES_USERNAME || 'postgres',
   password,
   database: 'test'
+}
+
+// pg 8.9.0 replaced its internal crypto implementation for auth with the crypto module
+const usesCrypto = semver.satisfies(pkg.version, '>=8.9.0')
+function skip (msg) {
+  if (usesCrypto && msg.Layer === 'crypto') {
+    return true
+  } else {
+    return false
+  }
 }
 
 let hasNative = false
@@ -242,7 +253,8 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
               emitter,
               subtests[t].cb.test,
               subtests[t].checks,
-              done
+              done,
+              { skip }
             )
           })
 
@@ -251,7 +263,8 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
               emitter,
               subtests[t].p.test,
               subtests[t].checks,
-              done
+              done,
+              { skip }
             )
           })
         }
@@ -269,7 +282,8 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
               emitter,
               subtests[t].cb.test,
               subtests[t].checks,
-              done
+              done,
+              { skip }
             )
           })
 
@@ -278,7 +292,8 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
               emitter,
               subtests[t].p.test,
               subtests[t].checks,
-              done
+              done,
+              { skip }
             )
           })
         }
@@ -324,7 +339,8 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
               emitter,
               subtests[t].cb.test,
               subtests[t].checks,
-              done
+              done,
+              { skip }
             )
           })
 
@@ -333,7 +349,8 @@ describe(`probes.pg ${pkg.version} pg-native ${nativeVer}`, function () {
               emitter,
               subtests[t].p.test,
               subtests[t].checks,
-              done
+              done,
+              { skip }
             )
           })
         }


### PR DESCRIPTION
With version `8.9.0`, `pg` [replaced its internal password hashing implementation](https://github.com/brianc/node-postgres/commit/9dfb3dccbfd78c088f093dd4c0c11bda7ccd2465) with one from Node's `crypto` module. Since we also instrument that module, new spans were showing up that the tests didn't expect.

It would be possible to add checks for these crypto spans, but that would be pretty counterproductive as they're implementation details of pg, a database driver making crypto calls internally is behaviour we should expect, and the order and precise nature of these internal calls is out of scope when testing correctness of the driver instrumentation.

This PR instead adds a way to ignore certain events when running checks to the test helper and uses it to ignore `crypto` spans when running tests on `pg >=8.9.0`.

(also some small tweaks to make tests run properly on arm)