### PR TITLE
Properly parse mongodb host from session

### DIFF
--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -295,8 +295,8 @@ module.exports = function (mongodb, options) {
 
         // define default kvpairs
         const remoteHost =
-          (options && options.hostAddress && options.hostAddress.toString()) || // .4.6.0
-          (options && options.session && options.session.client && options.session.client.s && options.session.client.s.url.replace('mongodb://', '')) || // .4.6.0
+          (options?.hostAddress?.toString()) ?? // .4.6.0
+          (options?.session?.client?.s && new URL(options.session.client.s.url).host) ?? // .4.6.0
           '' // for anything under 4.6 just leave empty
 
         let kvpairs = {


### PR DESCRIPTION
`RemoteHost` previously naively used the full url with the scheme trimmed, now it actually parses it and only uses the host