### PR TITLE
RemoteHost & RemoteUrl sanitisation

### DIFF
--- a/lib/probes/http.js
+++ b/lib/probes/http.js
@@ -105,6 +105,9 @@ function patchClient (module, options, protocol) {
       filtered.pathname = filtered.path.slice(0, i)
       filtered.search = filtered.path.slice(i + 1)
 
+      // Always remove auth
+      filtered.auth = ''
+
       // Remove query properties if filtering
       if (!conf.includeRemoteUrlParams) {
         filtered.search = ''
@@ -666,23 +669,27 @@ function getUrlFilterMode (req) {
 // Utility function that converts a URL object into an ordinary
 // options object as expected by the http.request and https.request
 // APIs.
-function urlToOptions (url) {
+function urlToOptions (u) {
+  if ("urlToHttpOptions" in url && typeof url.urlToHttpOptions === "function") {
+    return url.urlToHttpOptions(u)
+  }
+
   const options = {
-    protocol: url.protocol,
-    hostname: url.hostname.startsWith('[')
-      ? url.hostname.slice(1, -1)
-      : url.hostname,
-    hash: url.hash,
-    search: url.search,
-    pathname: url.pathname,
-    path: `${url.pathname}${url.search}`,
-    href: url.href
+    protocol: u.protocol,
+    hostname: u.hostname.startsWith('[')
+      ? u.hostname.slice(1, -1)
+      : u.hostname,
+    hash: u.hash,
+    search: u.search,
+    pathname: u.pathname,
+    path: `${u.pathname}${u.search}`,
+    href: u.href
   }
-  if (url.port !== '') {
-    options.port = Number(url.port)
+  if (u.port !== '') {
+    options.port = Number(u.port)
   }
-  if (url.username || url.password) {
-    options.auth = `${url.username}:${url.password}`
+  if (u.username || u.password) {
+    options.auth = `${u.username}:${u.password}`
   }
   return options
 }

--- a/lib/probes/mongodb.js
+++ b/lib/probes/mongodb.js
@@ -10,6 +10,9 @@ const logMissing = ao.makeLogMissing('mongodb')
 
 const requirePatch = require('../require-patch')
 
+// matches any url auth part containing a password
+const authRegex = /[^\s:]+:\S+@/g
+
 const prepQueryString = (obj) => {
   // conf is an external global
   return conf.sanitizeObject
@@ -229,13 +232,17 @@ module.exports = function (mongodb, options) {
 
           // prep kv pairs
           // define default kvpairs
-          const remoteHost =
-                (server && server.description && server.description.address) ||
-                (server && `${server.s && server.s.options && server.s.options.host}:${server.s && server.s.options && (server.s.options.port || 27017)}`) ||
-                ''
+          let remoteHost = undefined
+          remoteHost = remoteHost ?? (server?.s?.options?.host && `${server.s.options.host}:${server.s.options?.port ?? 27017}`)
+          try {
+            remoteHost = remoteHost ?? (server?.description?.address && new URL(server.description.address).host)
+          } catch {
+            // last resort
+            remoteHost = remoteHost ?? (server.description.address.replaceAll(authRegex, ''))
+          }
 
           let kvpairs = {
-            RemoteHost: remoteHost,
+            RemoteHost: remoteHost || '',
             Flavor: 'mongodb',
             Spec: 'query',
             QueryOp: 'command',
@@ -294,10 +301,14 @@ module.exports = function (mongodb, options) {
         /* eslint-enable no-unused-vars */
 
         // define default kvpairs
-        const remoteHost =
-          (options?.hostAddress?.toString()) ?? // .4.6.0
-          (options?.session?.client?.s && new URL(options.session.client.s.url).host) ?? // .4.6.0
-          '' // for anything under 4.6 just leave empty
+        let remoteHost = undefined
+        remoteHost = remoteHost ?? options?.hostAddress?.toString()
+        try {
+          remoteHost = remoteHost ?? (options?.session?.client?.s?.url && new URL(options.session.client.s.url).host)
+        } catch {
+          // last resort
+          remoteHost = remoteHost ?? (options.session.client.s.url.replaceAll(authRegex, ''))
+        }
 
         let kvpairs = {
           RemoteHost: remoteHost || '',

--- a/test/probes/http/client.js
+++ b/test/probes/http/client.js
@@ -1,7 +1,8 @@
 'use strict'
 
 exports.data = function (ctx) {
-  return { url: `${ctx.p}://localhost:${ctx.data.port}/?foo=bar` }
+  const auth = ctx.data.auth ? `${ctx.data.auth}@` : ''
+  return { url: `${ctx.p}://${auth}localhost:${ctx.data.port}/?foo=bar` }
 }
 
 exports.run = function (ctx, done) {


### PR DESCRIPTION
Adds support for a few discovered edgecases with previous mongo RemoteHost logic and adds sanitisation to RemoteUrl in http client instrumentation. Also adds tests for both.