### PR TITLE
Fix crash on unsupported Node versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -306,7 +306,7 @@ apm.debugLogging = function (setting) {
 // give a quick update
 const x = enabled ? '' : '(disabled)'
 log.debug(
-  `apm ${apm.version}${x}, bindings ${bindings.version}, oboe ${bindings.Config.getVersionString()}`
+  `apm ${apm.version}${x}, bindings ${bindings?.version ?? 'version unknown'}, oboe ${bindings?.Config?.getVersionString() ?? 'version unknown'}`
 )
 
 //


### PR DESCRIPTION
Removes undefined member access and replace with optional chaining + default values to not crash at startup on unsupported versions