### PR TITLE
solarwinds-apm 13.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solarwinds-apm",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solarwinds-apm",
-      "version": "12.0.0",
+      "version": "13.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ace-context": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solarwinds-apm",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "Agent for SolarWinds APM",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
- Node 20 support
- Node 14 support removed
- Cloud VM ID detection
- Fix error message on unsupported Node versions